### PR TITLE
Fix segfault when inputting three page-arguments

### DIFF
--- a/unpaper.c
+++ b/unpaper.c
@@ -1000,9 +1000,8 @@ int main(int argc, char* argv[]) {
         if ( inputWildcard )
             optind++;
 	
-	if(optind >= argc) { // see if any one of the last two optind++ has pushed over the array
+	if(optind >= argc) { // see if any one of the last two optind++ has pushed it over the array boundary
 		errOutput("not enough output files given.");
-		return -1;
 	}
         bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
         for(int i = 0; i < outputCount; i++) {
@@ -1011,7 +1010,6 @@ int main(int argc, char* argv[]) {
                 outputFileNames[i] = outputFilesBuffer[i];
             } else if ( optind >= argc ) {
                 errOutput("not enough output files given.");
-                return -1;
             } else {
                 outputFileNames[i] = argv[optind++];
             }


### PR DESCRIPTION
This fixes a probably very rare corner-case where unpaper segfaults.
Can be triggered by calling

> unpaper image1.pnm image2.pnm image3.pnm -overwrite

when all three files already exist.
The segfault is triggered by acessing `argv[optind]` in
`bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);`
because `optind` was incremented in the for-loop above and it isn't checked if if now is to big for the argv-array.
Because this was hard to catch without a debugger (even with -debug set) I also added some debug-output around the code. Never hurts to have that.
