### PR TITLE
add compare-image binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ compile
 depcomp
 install-sh
 missing
+compare-image
 test-driver
 test-suite.log
 tests/.dirstamp


### PR DESCRIPTION
when running `make check` the `compare-image` binary is created and it isn't in .gitignore as I think it should be.
