### PR TITLE
Better error checks in argument parsing.

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -185,7 +185,7 @@ void printEdges(int d) {
  */
 void parseSingleInt(const char*s, int* i, const char* option) {
     if ( sscanf(s, "%d", i) <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option %s. , expected integer.", s, option);
+        errOutput("couldn't parse argument '%s' for option %s, expected integer.", s, option);
     }
 }
 
@@ -201,14 +201,14 @@ void parseInts(const char* s, int i[2], const char* option) {
     char c;
     int scanned = sscanf(s, "%d%c%d", &i[0], &c, &i[1]);
     if ( scanned <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option %s. , expected integer(,integer).", s, option);
+        errOutput("couldn't parse argument '%s' for option %s, expected integer(,integer).", s, option);
     } else if ( scanned == 1 ) {
         i[1] = i[0]; // if second value is unset, copy first one into
     } else if ( scanned == 2 ) {
         // a single char in the middle but no other int set
-        errOutput("couldn't parse argument '%s' after '%d%c' for option %s. , expected integer,integer.", s, i[1], c, option);
+        errOutput("couldn't parse argument '%s' after '%d%c' for option %s, expected integer,integer.", s, i[1], c, option);
     } else if ( c != ',' ) {
-        errOutput("un, expected delimiter '%c' in argument '%s' for option %s. , expected integer,integer.", c, s, option);
+        errOutput("unexpected delimiter '%c' in argument '%s' for option %s, expected integer,integer.", c, s, option);
     }
 }
 
@@ -290,7 +290,7 @@ int parseColor(char* s) {
  */
 void parseSingleFloat(const char*s, float* f, const char* option) {
     if ( sscanf(s, "%f", f) <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option %s. , expected floating point number.", s, option);
+        errOutput("couldn't parse argument '%s' for option %s, expected floating point number.", s, option);
     }
 }
 
@@ -303,14 +303,14 @@ void parseFloats(const char* s, float f[2], const char* option) {
     char c;
     int scanned = sscanf(s, "%f%c%f", &f[0], &c, &f[1]);
     if ( scanned <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option %s. , expected float(,float).", s, option);
+        errOutput("couldn't parse argument '%s' for option %s, expected float(,float).", s, option);
     } else if ( scanned == 1 ) {
         f[1] = f[0]; // if second value is unset, copy first one into
     } else if ( scanned == 2 ) {
         // a single char in the middle but no other float set
-        errOutput("couldn't parse argument '%s' after '%f%c' for option %s. , expected float,float.", s, f[1], c, option);
+        errOutput("couldn't parse argument '%s' after '%f%c' for option %s, expected float,float.", s, f[1], c, option);
     } else if ( c != ',' ) {
-        errOutput("un, expected delimiter '%c' in argument '%s' for option %s. , expected float,float.", c, s, option);
+        errOutput("unexpected delimiter '%c' in argument '%s' for option %s, expected float,float.", c, s, option);
     }
 }
 

--- a/parse.c
+++ b/parse.c
@@ -185,7 +185,7 @@ void printEdges(int d) {
  */
 void parseSingleInt(const char*s, int* i, const char* option) {
     if ( sscanf(s, "%d", i) <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option '%s' as integer.", s, option);
+        errOutput("couldn't parse argument '%s' for option %s. , expected integer.", s, option);
     }
 }
 
@@ -193,15 +193,23 @@ void parseSingleInt(const char*s, int* i, const char* option) {
 /**
  * Parses either a single integer string, of a pair of two integers seperated
  * by a comma.
+ * @param s the string to parse
+ * @param i int array of size 2
+ * @param option the option for which the int(s) should be parsed
  */
-void parseInts(char* s, int i[2]) {
-    int scanned = sscanf(s, "%d,%d", &i[0], &i[1]);
+void parseInts(const char* s, int i[2], const char* option) {
+    char c;
+    int scanned = sscanf(s, "%d%c%d", &i[0], &c, &i[1]);
     if ( scanned <= 0 ) {
-        errOutput("couldn't parse argument '%s' as integer(,integer).", s);
+        errOutput("couldn't parse argument '%s' for option %s. , expected integer(,integer).", s, option);
     } else if ( scanned == 1 ) {
         i[1] = i[0]; // if second value is unset, copy first one into
+    } else if ( scanned == 2 ) {
+        // a single char in the middle but no other int set
+        errOutput("couldn't parse argument '%s' after '%d%c' for option %s. , expected integer,integer.", s, i[1], c, option);
+    } else if ( c != ',' ) {
+        errOutput("un, expected delimiter '%c' in argument '%s' for option %s. , expected integer,integer.", c, s, option);
     }
-    // everything was scanned in
 }
 
 
@@ -282,7 +290,7 @@ int parseColor(char* s) {
  */
 void parseSingleFloat(const char*s, float* f, const char* option) {
     if ( sscanf(s, "%f", f) <= 0 ) {
-        errOutput("couldn't parse argument '%s' for option '%s' as floating point number.", s, option);
+        errOutput("couldn't parse argument '%s' for option %s. , expected floating point number.", s, option);
     }
 }
 
@@ -291,12 +299,18 @@ void parseSingleFloat(const char*s, float* f, const char* option) {
  * Parses either a single float string, of a pair of two floats seperated
  * by a comma.
  */
-void parseFloats(char* s, float f[2]) {
-    f[0] = -1.0;
-    f[1] = -1.0;
-    sscanf(s, "%f,%f", &f[0], &f[1]);
-    if (f[1]==-1.0) {
+void parseFloats(const char* s, float f[2], const char* option) {
+    char c;
+    int scanned = sscanf(s, "%f%c%f", &f[0], &c, &f[1]);
+    if ( scanned <= 0 ) {
+        errOutput("couldn't parse argument '%s' for option %s. , expected float(,float).", s, option);
+    } else if ( scanned == 1 ) {
         f[1] = f[0]; // if second value is unset, copy first one into
+    } else if ( scanned == 2 ) {
+        // a single char in the middle but no other float set
+        errOutput("couldn't parse argument '%s' after '%f%c' for option %s. , expected float,float.", s, f[1], c, option);
+    } else if ( c != ',' ) {
+        errOutput("un, expected delimiter '%c' in argument '%s' for option %s. , expected float,float.", c, s, option);
     }
 }
 

--- a/parse.c
+++ b/parse.c
@@ -176,17 +176,32 @@ void printEdges(int d) {
 }
 
 
+
+/**
+ * Parse a single string to int
+ * @param s the string to parse
+ * @param i target int
+ * @param option a string containing the option for which the argument should be parsed (for error output)
+ */
+void parseSingleInt(const char*s, int* i, const char* option) {
+    if ( sscanf(s, "%d", i) <= 0 ) {
+        errOutput("couldn't parse argument '%s' for option '%s' as integer.", s, option);
+    }
+}
+
+
 /**
  * Parses either a single integer string, of a pair of two integers seperated
  * by a comma.
  */
 void parseInts(char* s, int i[2]) {
-    i[0] = -1;
-    i[1] = -1;
-    sscanf(s, "%d,%d", &i[0], &i[1]);
-    if (i[1]==-1) {
+    int scanned = sscanf(s, "%d,%d", &i[0], &i[1]);
+    if ( scanned <= 0 ) {
+        errOutput("couldn't parse argument '%s' as integer(,integer).", s);
+    } else if ( scanned == 1 ) {
         i[1] = i[0]; // if second value is unset, copy first one into
     }
+    // everything was scanned in
 }
 
 
@@ -207,6 +222,7 @@ static int parseSizeSingle(const char *s, int dpi) {
        multiply for dpi. */
     return (int)value;
 }
+
 
 /**
  * Parses a pair of size-values and returns it in pixels.
@@ -253,9 +269,21 @@ int parseColor(char* s) {
     if ( strcmp(s, "black") == 0 )
         return BLACK24;
     if ( strcmp(s, "white") == 0 )
-      return WHITE24;
+        return WHITE24;
 
     errOutput("cannot parse color '%s'.", s);
+}
+
+/**
+ * Parse a single string to float
+ * @param s the string to parse
+ * @param i target float
+ * @param option a string containing the option for which the argument should be parsed (for error output)
+ */
+void parseSingleFloat(const char*s, float* f, const char* option) {
+    if ( sscanf(s, "%f", f) <= 0 ) {
+        errOutput("couldn't parse argument '%s' for option '%s' as floating point number.", s, option);
+    }
 }
 
 

--- a/parse.h
+++ b/parse.h
@@ -28,17 +28,17 @@ int parseEdges(char* s);
 
 void printEdges(int d);
 
-void parseSingleInt(const char*s, int* i, const char* option);
+void parseSingleInt(const char* s, int* i, const char* option);
 
-void parseInts(char* s, int i[2]);
+void parseInts(const char* s, int i[2], const char* option);
 
 void parseSize(char* s, int i[2], int dpi);
 
 int parseColor(char* s);
 
-void parseSingleFloat(const char*s, float* f, const char* option);
+void parseSingleFloat(const char* s, float* f, const char* option);
 
-void parseFloats(char* s, float f[2]);
+void parseFloats(const char* s, float f[2], const char* option);
 
 char* implode(char* buf, const char* s[], int cnt);
 

--- a/parse.h
+++ b/parse.h
@@ -28,11 +28,15 @@ int parseEdges(char* s);
 
 void printEdges(int d);
 
+void parseSingleInt(const char*s, int* i, const char* option);
+
 void parseInts(char* s, int i[2]);
 
 void parseSize(char* s, int i[2], int dpi);
 
 int parseColor(char* s);
+
+void parseSingleFloat(const char*s, float* f, const char* option);
 
 void parseFloats(char* s, float f[2]);
 

--- a/unpaper.c
+++ b/unpaper.c
@@ -402,19 +402,19 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x7e:
-            sscanf(optarg,"%d", &startSheet);
+            parseSingleInt(optarg, &startSheet, "--start or --start-sheet");
             break;
 
         case 0x7f:
-            sscanf(optarg,"%d", &endSheet);
+            parseSingleInt(optarg, &endSheet, "--end or --end-sheet");
             break;
 
         case 0x80:
-            sscanf(optarg,"%d", &startInput);
+            parseSingleInt(optarg, &startInput, "--si or --start-input");
             break;
 
         case 0x81:
-            sscanf(optarg,"%d", &startOutput);
+            parseSingleInt(optarg, &startOutput, "--so or --start-output");
             break;
 
         case 'S':
@@ -436,7 +436,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x83:
-            sscanf(optarg, "%d", &preRotate);
+            parseSingleInt(optarg, &preRotate, "--pre-rotate");
             if ((preRotate != 0) && (abs(preRotate) != 90)) {
                 fprintf(stderr, "cannot set --pre-rotate value other than -90 or 90, ignoring.\n");
                 preRotate = 0;
@@ -444,7 +444,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x84:
-            sscanf(optarg,"%d", &postRotate);
+            parseSingleInt(optarg, &postRotate, "--post-rotate");
             if ((postRotate != 0) && (abs(postRotate) != 90)) {
                 fprintf(stderr, "cannot set --post-rotate value other than -90 or 90, ignoring.\n");
                 postRotate = 0;
@@ -469,11 +469,9 @@ int main(int argc, char* argv[]) {
 
         case 0x88:
             if ( preMaskCount < MAX_MASKS ) {
-                left = -1;
-                top = -1;
-                right = -1;
-                bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '--pre-mask' as INT,INT,INT,INT.", optarg);
+                }
                 preMask[preMaskCount][LEFT] = left;
                 preMask[preMaskCount][TOP] = top;
                 preMask[preMaskCount][RIGHT] = right;
@@ -502,18 +500,20 @@ int main(int argc, char* argv[]) {
             break;
 
         case 'z':
-            sscanf(optarg,"%f", &zoomFactor);
+            parseSingleFloat(optarg, &zoomFactor, "-z or --zoom");
             break;
 
         case 0x8c:
-            sscanf(optarg,"%f", &postZoomFactor);
+            parseSingleFloat(optarg, &postZoomFactor, "--post-zoom");
             break;
 
         case 'p':
             if ( pointCount < MAX_POINTS ) {
                 int x = -1;
                 int y = -1;
-                sscanf(optarg,"%d,%d", &x, &y);
+                if( sscanf(optarg,"%d,%d", &x, &y) < 2) {
+                    errOutput("couldn't parse argument '%s' for option '-p or --mask-scan-point'", optarg);
+                }
                 point[pointCount][X] = x;
                 point[pointCount][Y] = y;
                 pointCount++;
@@ -529,7 +529,9 @@ int main(int argc, char* argv[]) {
                 top = -1;
                 right = -1;
                 bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '-m or --mask' as INT,INT,INT,INT.", optarg);
+                }
                 mask[maskCount][LEFT] = left;
                 mask[maskCount][TOP] = top;
                 mask[maskCount][RIGHT] = right;
@@ -548,7 +550,9 @@ int main(int argc, char* argv[]) {
                 top = -1;
                 right = -1;
                 bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '-W or --wipe' as INT,INT,INT,INT.", optarg);
+                }
                 wipe[wipeCount][LEFT] = left;
                 wipe[wipeCount][TOP] = top;
                 wipe[wipeCount][RIGHT] = right;
@@ -566,7 +570,9 @@ int main(int argc, char* argv[]) {
                 top = -1;
                 right = -1;
                 bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '--pre-wipe' as INT,INT,INT,INT.", optarg);
+                }
                 preWipe[preWipeCount][LEFT] = left;
                 preWipe[preWipeCount][TOP] = top;
                 preWipe[preWipeCount][RIGHT] = right;
@@ -584,7 +590,9 @@ int main(int argc, char* argv[]) {
                 top = -1;
                 right = -1;
                 bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '--post-wipe' as INT,INT,INT,INT.", optarg);
+                }
                 postWipe[postWipeCount][LEFT] = left;
                 postWipe[postWipeCount][TOP] = top;
                 postWipe[postWipeCount][RIGHT] = right;
@@ -601,15 +609,21 @@ int main(int argc, char* argv[]) {
             break;
 
         case 'B':
-            sscanf(optarg,"%d,%d,%d,%d", &border[LEFT], &border[TOP], &border[RIGHT], &border[BOTTOM]);
+            if ( sscanf(optarg,"%d,%d,%d,%d", &border[LEFT], &border[TOP], &border[RIGHT], &border[BOTTOM]) < 4 ) {
+                errOutput("couldn't parse argument '%s' for option '-B or --border' as INT,INT,INT,INT.", optarg);
+            }
             break;
 
         case 0x90:
-            sscanf(optarg,"%d,%d,%d,%d", &preBorder[LEFT], &preBorder[TOP], &preBorder[RIGHT], &preBorder[BOTTOM]);
+            if ( sscanf(optarg,"%d,%d,%d,%d", &preBorder[LEFT], &preBorder[TOP], &preBorder[RIGHT], &preBorder[BOTTOM]) < 4 ) {
+                errOutput("couldn't parse argument '%s' for option '--pre-border' as INT,INT,INT,INT.", optarg);
+            }
             break;
 
         case 0x91:
-            sscanf(optarg,"%d,%d,%d,%d", &postBorder[LEFT], &postBorder[TOP], &postBorder[RIGHT], &postBorder[BOTTOM]);
+            if ( sscanf(optarg,"%d,%d,%d,%d", &postBorder[LEFT], &postBorder[TOP], &postBorder[RIGHT], &postBorder[BOTTOM]) < 4 ) {
+                errOutput("couldn't parse argument '%s' for option '--post-border' as INT,INT,INT,INT.", optarg);
+            }
             break;
 
         case 0x92:
@@ -642,7 +656,9 @@ int main(int argc, char* argv[]) {
                 top = -1;
                 right = -1;
                 bottom = -1;
-                sscanf(optarg,"%d,%d,%d,%d", &left, &top, &right, &bottom); // x1, y1, x2, y2
+               if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
+                    errOutput("couldn't parse argument '%s' for option '--bx or --blackfilter-scan-exclude' as INT,INT,INT,INT.", optarg);
+                }
                 blackfilterExclude[blackfilterExcludeCount][LEFT] = left;
                 blackfilterExclude[blackfilterExcludeCount][TOP] = top;
                 blackfilterExclude[blackfilterExcludeCount][RIGHT] = right;
@@ -655,7 +671,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x99:
-            sscanf(optarg, "%d", &blackfilterIntensity);
+            parseSingleInt(optarg, &blackfilterIntensity, "--bi or --blackfilter-intensity");
             break;
 
         case 0x9a:
@@ -663,7 +679,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x9b:
-            sscanf(optarg, "%d", &noisefilterIntensity);
+            parseSingleInt(optarg, &noisefilterIntensity, "--ni or --noisefilter-intensity");
             break;
 
         case 0x9c:
@@ -679,7 +695,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x9f:
-            sscanf(optarg, "%f", &blurfilterIntensity);
+            parseSingleFloat(optarg, &blurfilterIntensity, "--li or --blurfilter-intensity");
             break;
 
         case 0xa0:
@@ -695,7 +711,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xa3:
-            sscanf(optarg, "%f", &grayfilterThreshold);
+            parseSingleFloat(optarg, &grayfilterThreshold, "--gt or --grayfilter-threshold");
             break;
 
         case 0xa4:
@@ -723,15 +739,19 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xaa:
-            sscanf(optarg,"%d,%d", &maskScanMinimum[WIDTH], &maskScanMinimum[HEIGHT]);
+            if ( sscanf(optarg,"%d,%d", &maskScanMinimum[WIDTH], &maskScanMinimum[HEIGHT]) < 2 ) {
+                errOutput("couldn't parse argument '%s' for option '--mm or --mask-scan-minimum' as INT,INT.");
+            }
             break;
 
         case 0xab:
-            sscanf(optarg,"%d,%d", &maskScanMaximum[WIDTH], &maskScanMaximum[HEIGHT]);
+            if ( sscanf(optarg,"%d,%d", &maskScanMaximum[WIDTH], &maskScanMaximum[HEIGHT]) < 2 ) {
+                errOutput("couldn't parse argument '%s' for option '--mM or --mask-scan-maximum' as INT,INT.");
+            }
             break;
 
         case 0xac:
-            sscanf(optarg,"%d", &maskColor);
+            parseSingleInt(optarg, &maskColor, "--mc or --mask-color");
             break;
 
         case 0xad:
@@ -747,23 +767,23 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xb0:
-            sscanf(optarg,"%d", &deskewScanSize);
+            parseSingleInt(optarg, &deskewScanSize, "--ds or --deskew-scan-size");
             break;
 
         case 0xb1:
-            sscanf(optarg,"%f", &deskewScanDepth);
+            parseSingleFloat(optarg, &deskewScanDepth, "--dd or --deskew-scan-depth");
             break;
 
         case 0xb2:
-            sscanf(optarg,"%f", &deskewScanRange);
+            parseSingleFloat(optarg, &deskewScanRange, "--dr or --deskew-scan-range");
             break;
 
         case 0xb3:
-            sscanf(optarg,"%f", &deskewScanStep);
+            parseSingleFloat(optarg, &deskewScanStep, "--dp or --deskew-scan-step");
             break;
 
         case 0xb4:
-            sscanf(optarg,"%f", &deskewScanDeviation);
+            parseSingleFloat(optarg, &deskewScanDeviation, "--dv or --deskew-scan-deviation");
             break;
 
         case 0xb5:
@@ -807,11 +827,11 @@ int main(int argc, char* argv[]) {
             break;
 
         case 'w':
-            sscanf(optarg,"%f", &whiteThreshold);
+            parseSingleFloat(optarg, &whiteThreshold, "-w or --white-threshold");
             break;
 
         case 'b':
-            sscanf(optarg,"%f", &blackThreshold);
+            parseSingleFloat(optarg, &blackThreshold, "-b or --black-threshold");
             break;
 
         case 0xbf:
@@ -850,16 +870,12 @@ int main(int argc, char* argv[]) {
             writeoutput = false;
             break;
 
-        case 0xc5:
-            // Deprecated function, ignore.
-            break;
-
         case 0xc6:
             multisheets = false;
             break;
 
         case 0xc7:
-            sscanf(optarg,"%d", &dpi);
+            parseSingleInt(optarg, &dpi, "--dpi");
             break;
 
         case 't':
@@ -869,6 +885,8 @@ int main(int argc, char* argv[]) {
                 outputPixFmt = AV_PIX_FMT_GRAY8;
             } else if ( strcmp(optarg, "ppm") == 0 ) {
                 outputPixFmt = AV_PIX_FMT_RGB24;
+            } else {
+                errOutput("unknown format '%s' for option '-t or --type'. Allowed types are pbm, pgm or ppm.", optarg);
             }
             break;
 

--- a/unpaper.c
+++ b/unpaper.c
@@ -402,19 +402,19 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x7e:
-            parseSingleInt(optarg, &startSheet, "--start or --start-sheet");
+            parseSingleInt(optarg, &startSheet, "'--start' or '--start-sheet'");
             break;
 
         case 0x7f:
-            parseSingleInt(optarg, &endSheet, "--end or --end-sheet");
+            parseSingleInt(optarg, &endSheet, "'--end' or '--end-sheet'");
             break;
 
         case 0x80:
-            parseSingleInt(optarg, &startInput, "--si or --start-input");
+            parseSingleInt(optarg, &startInput, "'--si' or '--start-input'");
             break;
 
         case 0x81:
-            parseSingleInt(optarg, &startOutput, "--so or --start-output");
+            parseSingleInt(optarg, &startOutput, "'--so' or '--start-output'");
             break;
 
         case 'S':
@@ -436,7 +436,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x83:
-            parseSingleInt(optarg, &preRotate, "--pre-rotate");
+            parseSingleInt(optarg, &preRotate, "'--pre-rotate'");
             if ((preRotate != 0) && (abs(preRotate) != 90)) {
                 fprintf(stderr, "cannot set --pre-rotate value other than -90 or 90, ignoring.\n");
                 preRotate = 0;
@@ -444,7 +444,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x84:
-            parseSingleInt(optarg, &postRotate, "--post-rotate");
+            parseSingleInt(optarg, &postRotate, "'--post-rotate'");
             if ((postRotate != 0) && (abs(postRotate) != 90)) {
                 fprintf(stderr, "cannot set --post-rotate value other than -90 or 90, ignoring.\n");
                 postRotate = 0;
@@ -500,11 +500,11 @@ int main(int argc, char* argv[]) {
             break;
 
         case 'z':
-            parseSingleFloat(optarg, &zoomFactor, "-z or --zoom");
+            parseSingleFloat(optarg, &zoomFactor, "'-z' or '--zoom'");
             break;
 
         case 0x8c:
-            parseSingleFloat(optarg, &postZoomFactor, "--post-zoom");
+            parseSingleFloat(optarg, &postZoomFactor, "'--post-zoom'");
             break;
 
         case 'p':
@@ -512,7 +512,7 @@ int main(int argc, char* argv[]) {
                 int x = -1;
                 int y = -1;
                 if( sscanf(optarg,"%d,%d", &x, &y) < 2) {
-                    errOutput("couldn't parse argument '%s' for option '-p or --mask-scan-point'", optarg);
+                    errOutput("couldn't parse argument '%s' for option '-p' or '--mask-scan-point'", optarg);
                 }
                 point[pointCount][X] = x;
                 point[pointCount][Y] = y;
@@ -530,7 +530,7 @@ int main(int argc, char* argv[]) {
                 right = -1;
                 bottom = -1;
                 if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
-                    errOutput("couldn't parse argument '%s' for option '-m or --mask' as INT,INT,INT,INT.", optarg);
+                    errOutput("couldn't parse argument '%s' for option '-m' or '--mask' as INT,INT,INT,INT.", optarg);
                 }
                 mask[maskCount][LEFT] = left;
                 mask[maskCount][TOP] = top;
@@ -551,7 +551,7 @@ int main(int argc, char* argv[]) {
                 right = -1;
                 bottom = -1;
                 if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
-                    errOutput("couldn't parse argument '%s' for option '-W or --wipe' as INT,INT,INT,INT.", optarg);
+                    errOutput("couldn't parse argument '%s' for option '-W' or '--wipe' as INT,INT,INT,INT.", optarg);
                 }
                 wipe[wipeCount][LEFT] = left;
                 wipe[wipeCount][TOP] = top;
@@ -605,12 +605,12 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x8f:
-            parseInts(optarg, middleWipe);
+            parseInts(optarg, middleWipe, "'--mw' or '--middle-wipe'");
             break;
 
         case 'B':
             if ( sscanf(optarg,"%d,%d,%d,%d", &border[LEFT], &border[TOP], &border[RIGHT], &border[BOTTOM]) < 4 ) {
-                errOutput("couldn't parse argument '%s' for option '-B or --border' as INT,INT,INT,INT.", optarg);
+                errOutput("couldn't parse argument '%s' for option '-B' or '--border' as INT,INT,INT,INT.", optarg);
             }
             break;
 
@@ -635,19 +635,19 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x94:
-            parseInts(optarg, blackfilterScanSize);
+            parseInts(optarg, blackfilterScanSize, "'--bs' or '--blackfilter-scan-size'");
             break;
 
         case 0x95:
-            parseInts(optarg, blackfilterScanDepth);
+            parseInts(optarg, blackfilterScanDepth, "'--bd' or '--blackfilter-scan-depth'");
             break;
 
         case 0x96:
-            parseInts(optarg, blackfilterScanStep);
+            parseInts(optarg, blackfilterScanStep, "'--bp' or '--blackfilter-scan-step'");
             break;
 
         case 0x97:
-            sscanf(optarg, "%f", &blackfilterScanThreshold);
+            parseSingleFloat(optarg, &blackfilterScanThreshold, "'--bt' or '--blackfilter-scan-threshold'");
             break;
 
         case 0x98:
@@ -657,7 +657,7 @@ int main(int argc, char* argv[]) {
                 right = -1;
                 bottom = -1;
                if ( sscanf(optarg, "%d,%d,%d,%d", &left, &top, &right, &bottom) /* x1, y1, x2, y2 */ < 4 ) {
-                    errOutput("couldn't parse argument '%s' for option '--bx or --blackfilter-scan-exclude' as INT,INT,INT,INT.", optarg);
+                    errOutput("couldn't parse argument '%s' for option '--bx' or '--blackfilter-scan-exclude' as INT,INT,INT,INT.", optarg);
                 }
                 blackfilterExclude[blackfilterExcludeCount][LEFT] = left;
                 blackfilterExclude[blackfilterExcludeCount][TOP] = top;
@@ -671,7 +671,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x99:
-            parseSingleInt(optarg, &blackfilterIntensity, "--bi or --blackfilter-intensity");
+            parseSingleInt(optarg, &blackfilterIntensity, "'--bi' or '--blackfilter-intensity'");
             break;
 
         case 0x9a:
@@ -679,7 +679,7 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x9b:
-            parseSingleInt(optarg, &noisefilterIntensity, "--ni or --noisefilter-intensity");
+            parseSingleInt(optarg, &noisefilterIntensity, "'--ni' or '--noisefilter-intensity'");
             break;
 
         case 0x9c:
@@ -687,15 +687,15 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0x9d:
-            parseInts(optarg, blurfilterScanSize);
+            parseInts(optarg, blurfilterScanSize, "'--ls' or '--blurfilter-scan-size'");
             break;
 
         case 0x9e:
-            parseInts(optarg, blurfilterScanStep);
+            parseInts(optarg, blurfilterScanStep, "'--lp' or '--blurfilter-scan-step'");
             break;
 
         case 0x9f:
-            parseSingleFloat(optarg, &blurfilterIntensity, "--li or --blurfilter-intensity");
+            parseSingleFloat(optarg, &blurfilterIntensity, "'--li' or '--blurfilter-intensity'");
             break;
 
         case 0xa0:
@@ -703,15 +703,15 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xa1:
-            parseInts(optarg, grayfilterScanSize);
+            parseInts(optarg, grayfilterScanSize, "'--gs' or '--grayfilter-scan-size'");
             break;
 
         case 0xa2:
-            parseInts(optarg, grayfilterScanStep);
+            parseInts(optarg, grayfilterScanStep, "'--gp' or '--grayfilter-scan-step'");
             break;
 
         case 0xa3:
-            parseSingleFloat(optarg, &grayfilterThreshold, "--gt or --grayfilter-threshold");
+            parseSingleFloat(optarg, &grayfilterThreshold, "'--gt' or '--grayfilter-threshold'");
             break;
 
         case 0xa4:
@@ -723,35 +723,35 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xa6:
-            parseInts(optarg, maskScanSize);
+            parseInts(optarg, maskScanSize, "'--ms' or '--mask-scan-size'");
             break;
 
         case 0xa7:
-            parseInts(optarg, maskScanDepth);
+            parseInts(optarg, maskScanDepth, "'--md' or '--mash-scan-depth'");
             break;
 
         case 0xa8:
-            parseInts(optarg, maskScanStep);
+            parseInts(optarg, maskScanStep, "'--mp' or '--mask-scan-step'");
             break;
 
         case 0xa9:
-            parseFloats(optarg, maskScanThreshold);
+            parseFloats(optarg, maskScanThreshold, "'--mt' or '--mask-scan-threshold'");
             break;
 
         case 0xaa:
             if ( sscanf(optarg,"%d,%d", &maskScanMinimum[WIDTH], &maskScanMinimum[HEIGHT]) < 2 ) {
-                errOutput("couldn't parse argument '%s' for option '--mm or --mask-scan-minimum' as INT,INT.");
+                errOutput("couldn't parse argument '%s' for option '--mm' or '--mask-scan-minimum' as INT,INT.");
             }
             break;
 
         case 0xab:
             if ( sscanf(optarg,"%d,%d", &maskScanMaximum[WIDTH], &maskScanMaximum[HEIGHT]) < 2 ) {
-                errOutput("couldn't parse argument '%s' for option '--mM or --mask-scan-maximum' as INT,INT.");
+                errOutput("couldn't parse argument '%s' for option '--mM' or '--mask-scan-maximum' as INT,INT.");
             }
             break;
 
         case 0xac:
-            parseSingleInt(optarg, &maskColor, "--mc or --mask-color");
+            parseSingleInt(optarg, &maskColor, "'--mc' or '--mask-color'");
             break;
 
         case 0xad:
@@ -766,24 +766,24 @@ int main(int argc, char* argv[]) {
             deskewScanEdges = parseEdges(optarg);
             break;
 
-        case 0xb0:
-            parseSingleInt(optarg, &deskewScanSize, "--ds or --deskew-scan-size");
+         case 0xb0:
+            parseSingleInt(optarg, &deskewScanSize, "'--ds' or '--deskew-scan-size'");
             break;
 
         case 0xb1:
-            parseSingleFloat(optarg, &deskewScanDepth, "--dd or --deskew-scan-depth");
+            parseSingleFloat(optarg, &deskewScanDepth, "'--dd' or '--deskew-scan-depth'");
             break;
 
         case 0xb2:
-            parseSingleFloat(optarg, &deskewScanRange, "--dr or --deskew-scan-range");
+            parseSingleFloat(optarg, &deskewScanRange, "'--dr' or '--deskew-scan-range'");
             break;
 
         case 0xb3:
-            parseSingleFloat(optarg, &deskewScanStep, "--dp or --deskew-scan-step");
+            parseSingleFloat(optarg, &deskewScanStep, "'--dp' or '--deskew-scan-step'");
             break;
 
         case 0xb4:
-            parseSingleFloat(optarg, &deskewScanDeviation, "--dv or --deskew-scan-deviation");
+            parseSingleFloat(optarg, &deskewScanDeviation, "'--dv' or '--deskew-scan-deviation'");
             break;
 
         case 0xb5:
@@ -795,15 +795,15 @@ int main(int argc, char* argv[]) {
             break;
 
         case 0xb7:
-            parseInts(optarg, borderScanSize);
+            parseInts(optarg, borderScanSize, "'--Bs' or '--border-scan-size'");
             break;
 
         case 0xb8:
-            parseInts(optarg, borderScanStep);
+            parseInts(optarg, borderScanStep, "'--Bp' or '--border-scan-step'");
             break;
 
         case 0xb9:
-            parseInts(optarg, borderScanThreshold);
+            parseInts(optarg, borderScanThreshold, "'--Bt' or '--border-scan-threshold'");
             break;
 
         case 0xba:
@@ -827,11 +827,11 @@ int main(int argc, char* argv[]) {
             break;
 
         case 'w':
-            parseSingleFloat(optarg, &whiteThreshold, "-w or --white-threshold");
+            parseSingleFloat(optarg, &whiteThreshold, "'-w' or '--white-threshold'");
             break;
 
         case 'b':
-            parseSingleFloat(optarg, &blackThreshold, "-b or --black-threshold");
+            parseSingleFloat(optarg, &blackThreshold, "'-b' or '--black-threshold'");
             break;
 
         case 0xbf:
@@ -874,8 +874,8 @@ int main(int argc, char* argv[]) {
             multisheets = false;
             break;
 
-        case 0xc7:
-            parseSingleInt(optarg, &dpi, "--dpi");
+       case 0xc7:
+            parseSingleInt(optarg, &dpi, "'--dpi'");
             break;
 
         case 't':
@@ -886,7 +886,7 @@ int main(int argc, char* argv[]) {
             } else if ( strcmp(optarg, "ppm") == 0 ) {
                 outputPixFmt = AV_PIX_FMT_RGB24;
             } else {
-                errOutput("unknown format '%s' for option '-t or --type'. Allowed types are pbm, pgm or ppm.", optarg);
+                errOutput("unknown format '%s' for option '-t' or '--type'. Allowed types are pbm, pgm or ppm.", optarg);
             }
             break;
 

--- a/unpaper.c
+++ b/unpaper.c
@@ -740,13 +740,13 @@ int main(int argc, char* argv[]) {
 
         case 0xaa:
             if ( sscanf(optarg,"%d,%d", &maskScanMinimum[WIDTH], &maskScanMinimum[HEIGHT]) < 2 ) {
-                errOutput("couldn't parse argument '%s' for option '--mm' or '--mask-scan-minimum' as INT,INT.");
+                errOutput("couldn't parse argument '%s' for option '--mm' or '--mask-scan-minimum' as INT,INT.", optarg);
             }
             break;
 
         case 0xab:
             if ( sscanf(optarg,"%d,%d", &maskScanMaximum[WIDTH], &maskScanMaximum[HEIGHT]) < 2 ) {
-                errOutput("couldn't parse argument '%s' for option '--mM' or '--mask-scan-maximum' as INT,INT.");
+                errOutput("couldn't parse argument '%s' for option '--mM' or '--mask-scan-maximum' as INT,INT.", optarg);
             }
             break;
 


### PR DESCRIPTION
This should stop a lot of weird behaviour if a user inputs a wrong argument and unpaper just works with that without ever checking.
Also created two methods (one for float, one for int) which parse a single int/float.
These methods also get a string of the option for which the argument is parsed.
This allows to display an error like "failed parsing of 'wrong' for option --option" to be displayed.
