### PR TITLE
Throw error on an inputfile which doesn't exist but don't break inputWil...

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,9 +38,9 @@ TESTS = tests/runtestA1.sh tests/runtestB1.sh tests/runtestB2.sh	\
         tests/runtestD3.sh tests/runtestE1.sh tests/runtestE2.sh	\
         tests/runtestE3.sh tests/runtestF1.sh tests/runtestF2.sh	\
         tests/runtestF3.sh tests/runtestG1.sh tests/runtestG2.sh	\
-	tests/runtestG3.sh
+        tests/runtestG3.sh tests/NoInputFile.sh
 
-XFAIL_TESTS = tests/runtestG3.sh
+XFAIL_TESTS = tests/runtestG3.sh tests/NoInputFile.sh
 
 EXTRA_DIST = $(TESTS) tests/imgsrc001.png tests/imgsrc002.png           \
              tests/imgsrc003.png tests/imgsrc004.png                    \
@@ -71,7 +71,8 @@ CLEANFILES = tests/.dirstamp tests/resultsA1.pbm tests/resultsB1.ppm    \
 	     tests/resultsE301.pbm tests/resultsE302.pbm                \
 	     tests/resultsF11.pbm tests/resultsF21.pbm                  \
 	     tests/resultsF3.pbm tests/resultsG1.pbm                    \
-	     tests/resultsG2.pbm tests/resultsG3.pbm
+	     tests/resultsG2.pbm tests/resultsG3.pbm                    \
+	     tests/resutsNoInputFile.pbm
 
 %.1: %.1.xml
 	$(AM_V_GEN)$(XSLTPROC) \

--- a/tests/NoInputFile.sh
+++ b/tests/NoInputFile.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "[NoInputFile] input file doesn't exist"
+
+set -e
+set -x
+
+./unpaper -v tests/NoInputFile.pbm tests/resultsNoInputFile.pbm

--- a/unpaper.c
+++ b/unpaper.c
@@ -991,7 +991,9 @@ int main(int argc, char* argv[]) {
             if ( inputFileNames[i] != NULL ) {
                 struct stat statBuf;
                 if ( stat(inputFileNames[i], &statBuf) != 0 ) {
-                    if ( endSheet == -1 ) {
+                    if ( inputWildcard ) {
+                        // this jumps to the end of the processing-loop
+                        // endSheet = nr-1 exits the loop
                         endSheet = nr-1;
                         goto sheet_end;
                     } else {


### PR DESCRIPTION
...dcard support.
Without this would simply quit without throwing an error:
`unpaper NoSuchFile out.pnm`.
Now it throws an error.
