### PR TITLE
fix ffmpeg incompatibility

### DIFF
--- a/file.c
+++ b/file.c
@@ -93,10 +93,21 @@ void loadImage(const char *filename, AVFrame **image) {
     if (pkt.stream_index != 0)
         errOutput("unable to open file %s: invalid stream.", filename);
 
+    while (!got_frame && pkt.data) {
+
+        if (pkt.size <= 0) {
+            pkt.data = NULL;
+            pkt.size = 0;
+        }
+
     ret = avcodec_decode_video2(avctx, frame, &got_frame, &pkt);
     if (ret < 0) {
         av_strerror(ret, errbuff, sizeof(errbuff));
         errOutput("unable to open file %s: %s", filename, errbuff);
+    }
+
+        pkt.data += ret;
+        pkt.size -= ret;
     }
 
     switch(frame->format) {


### PR DESCRIPTION
Thanks to Andreas Cadhalpun andreas.cadhalpun@googlemail.com for the patch.

Received 2015-09-28 via debian bug
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=800312
with the following comment:

Not really. unpaper just doesn't use the API correctly.
More specifically, it doesn't make sure it actually got a frame.
The following change makes it work:

Closes: #39
