### PR TITLE
Build with different configurations on GitHub Actions.

### DIFF
--- a/.github/workflows/meson-build-and-test.yml
+++ b/.github/workflows/meson-build-and-test.yml
@@ -17,6 +17,10 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc, clang]
+        meson_setup_flags:
+          - ""
+          - "--buildtype=debugoptimized"
+          - "--buildtype=debugoptimized -Db_lto=true"
 
     steps:
     - uses: actions/checkout@v1
@@ -29,7 +33,7 @@ jobs:
       run: |
         sudo apt install libavcodec-dev libavutil-dev libavformat-dev python3
         pip install 'sphinx >= 3.4' pytest pillow
-    - run: meson setup builddir/
+    - run: meson setup ${{ matrix.meson_setup_flags }} builddir/
       env:
         CC: ${{ matrix.compiler }}
     - run: meson test -C builddir/ -v


### PR DESCRIPTION
unpaper is known to be finnicky (and failing tests) on optimized builds, so make sure to test it.

Also make sure that the LTO build works fine.