### PR TITLE
pre-commit autoupdate.

### DIFF
--- a/.github/workflows/meson-build-and-test.yml
+++ b/.github/workflows/meson-build-and-test.yml
@@ -36,6 +36,8 @@ jobs:
     - run: meson setup ${{ matrix.meson_setup_flags }} builddir/
       env:
         CC: ${{ matrix.compiler }}
+    - run: meson compile -C builddir/ -v
+      timeout-minutes: 15
     - run: meson test -C builddir/ -v
       timeout-minutes: 30
     - name: Test installation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/fsfe/reuse-tool
@@ -12,6 +12,6 @@ repos:
     hooks:
     - id: reuse
 -   repo: https://github.com/doublify/pre-commit-clang-format
-    rev: master
+    rev: 62302476d0da01515660132d76902359bed0f782
     hooks:
     -   id: clang-format

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,6 +6,11 @@ project = "unpaper"
 copyright = "2020, The unpaper Authors"
 author = "The unpaper Authors"
 
+# Avoid generate sub-directory for the man pages during build:
+# https://github.com/sphinx-doc/sphinx/issues/9217
+# This appears incompatible with the Meson expectation.
+man_make_section_directory = False
+
 man_pages = [
     ("unpaper.1", "unpaper", "unpaper", "The unpaper authors", 1),
 ]

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ unpaper = executable(
     install : true,
 )
 
-sphinx = find_program('sphinx-build', required: true)
+sphinx = find_program('sphinx-build', required: true, version: '>= 3.4')
 
 custom_target(
     'man',


### PR DESCRIPTION
## pre-commit autoupdate.


## CI: explicitly run `meson compile` as a step.

Without this change, the bulk of the binary is built during the test
phase, and the man page is built during the install phase.

Unfortunately the install phase does not support the `-v` flag, so the
command line parameters are not logged for that.

## Disable the man page section directory generation.

This makes Sphinx 4.0.0 and 4.0.1 work again to build unpaper. The
default has been turned back off for 4.0.2 (not released yet) but it
might be turned on by default in 4.1.0 again.

## Sphinx: apply the same version check as documented.

This is pretty much a no-op right now but it should allow to update it
together with the documentation as needed.
