### PR TITLE
Fix string handling for parseMultiIndex() in case of non-range.

### DIFF
--- a/tests/unpaper_tests.py
+++ b/tests/unpaper_tests.py
@@ -424,3 +424,12 @@ def test_no_overwrite_existing_file(imgsrc_path, tmp_path):
     )
     assert unpaper_result.returncode != 0
     assert result_path.stat().st_size == 0
+
+
+def test_invalid_multi_index(imgsrc_path, tmp_path):
+    source_path = imgsrc_path / "imgsrc001.png"
+    result_path = tmp_path / "result.pbm"
+    unpaper_result = run_unpaper(
+        "--no-processing", "1-", str(source_path), str(result_path), check=False
+    )
+    assert unpaper_result.returncode != 0


### PR DESCRIPTION
Previously, it was possible that `c` was randomly set to `-`, but then
`s2` would be dangling.

This makes sure that if s2 is left dangling it is never referenced.