### PR TITLE
Apply const specifiers as part of refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _deps/
 _build/
 builddir/
 tests/__pycache__/
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v2.1.0
     hooks:
     - id: reuse
--   repo: https://github.com/doublify/pre-commit-clang-format
-    rev: 62302476d0da01515660132d76902359bed0f782
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
     hooks:
     -   id: clang-format

--- a/file.c
+++ b/file.c
@@ -139,7 +139,7 @@ void saveImage(char *filename, AVFrame *input, int outputPixFmt) {
   char errbuff[1024];
 
   if (avformat_alloc_output_context2(&out_ctx, NULL, "image2", filename) < 0 ||
-    out_ctx == NULL) {
+      out_ctx == NULL) {
     errOutput("unable to allocate output context.");
   }
 

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -700,7 +700,7 @@ void detectMasks(AVFrame *image) {
  * Permanently applies image masks. Each pixel which is not covered by at least
  * one mask is set to maskColor.
  */
-void applyMasks(Mask *masks, const int masksCount, AVFrame *image) {
+void applyMasks(const Mask *masks, const int masksCount, AVFrame *image) {
   if (masksCount <= 0) {
     return;
   }
@@ -724,7 +724,7 @@ void applyMasks(Mask *masks, const int masksCount, AVFrame *image) {
  * Permanently wipes out areas of an images. Each pixel covered by a wipe-area
  * is set to wipeColor.
  */
-void applyWipes(Mask *area, int areaCount, AVFrame *image) {
+void applyWipes(const Mask *area, int areaCount, AVFrame *image) {
   for (int i = 0; i < areaCount; i++) {
     int count = 0;
     for (int y = area[i][TOP]; y <= area[i][BOTTOM]; y++) {

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -23,7 +23,7 @@
  * image processing functions                                               *
  ****************************************************************************/
 
-static inline bool inMask(int x, int y, Mask mask) {
+static inline bool inMask(int x, int y, const Mask mask) {
   return (x >= mask[LEFT]) && (x <= mask[RIGHT]) && (y >= mask[TOP]) &&
          (y <= mask[BOTTOM]);
 }
@@ -31,15 +31,15 @@ static inline bool inMask(int x, int y, Mask mask) {
 /**
  * Tests if masks a and b overlap.
  */
-static inline bool masksOverlap(Mask a, Mask b) {
+static inline bool masksOverlap(const Mask a, const Mask b) {
   return (inMask(a[LEFT], a[TOP], b) || inMask(a[RIGHT], a[BOTTOM], b));
 }
 
 /**
  * Tests if at least one mask in masks overlaps with m.
  */
-static bool masksOverlapAny(Mask m,
-                            Mask *masks, int masksCount) {
+static bool masksOverlapAny(const Mask m,
+                            const Mask *masks, int masksCount) {
   for (int i = 0; i < masksCount; i++) {
     if (masksOverlap(m, masks[i])) {
       return true;
@@ -61,7 +61,7 @@ static bool masksOverlapAny(Mask m,
  * this is negative for negative radians.
  */
 static int detectEdgeRotationPeak(float m, int shiftX, int shiftY,
-                                  AVFrame *image, Mask mask) {
+                                  AVFrame *image, const Mask mask) {
   int width = mask[RIGHT] - mask[LEFT] + 1;
   int height = mask[BOTTOM] - mask[TOP] + 1;
   int mid;
@@ -167,7 +167,7 @@ static int detectEdgeRotationPeak(float m, int shiftX, int shiftY,
  * is non-zero, and what sign this shifting value has.
  */
 static float detectEdgeRotation(int shiftX, int shiftY, AVFrame *image,
-                                Mask mask) {
+                                const Mask mask) {
   // either shiftX or shiftY is 0, the other value is -i|+i
   // depending on shiftX/shiftY the start edge for shifting is determined
   int maxPeak = 0;
@@ -194,7 +194,7 @@ static float detectEdgeRotation(int shiftX, int shiftY, AVFrame *image,
  * the horizontal or vertical edges of the area specified by left, top, right,
  * bottom.
  */
-float detectRotation(AVFrame *image, Mask mask) {
+float detectRotation(AVFrame *image, const Mask mask) {
   float rotation[4];
   int count = 0;
   float total;
@@ -584,12 +584,12 @@ static int detectEdge(int startX, int startY, int shiftX, int shiftY,
  * no mask could be detected
  */
 static bool detectMask(int startX, int startY, int maskScanDirections,
-                       int maskScanSize[DIRECTIONS_COUNT],
-                       int maskScanDepth[DIRECTIONS_COUNT],
-                       int maskScanStep[DIRECTIONS_COUNT],
-                       float maskScanThreshold[DIRECTIONS_COUNT],
-                       int maskScanMinimum[DIMENSIONS_COUNT],
-                       int maskScanMaximum[DIMENSIONS_COUNT], int *left,
+                       const int maskScanSize[DIRECTIONS_COUNT],
+                       const int maskScanDepth[DIRECTIONS_COUNT],
+                       const int maskScanStep[DIRECTIONS_COUNT],
+                       const float maskScanThreshold[DIRECTIONS_COUNT],
+                       const int maskScanMinimum[DIMENSIONS_COUNT],
+                       const int maskScanMaximum[DIMENSIONS_COUNT], int *left,
                        int *top, int *right, int *bottom, AVFrame *image) {
   int width;
   int height;
@@ -814,7 +814,7 @@ void flipRotate(int direction, AVFrame **image) {
  */
 static void blackfilterScan(int stepX, int stepY, int size, int dep,
                             unsigned int absBlackfilterScanThreshold,
-                            Mask *exclude,
+                            const Mask *exclude,
                             int excludeCount, int intensity, AVFrame *image) {
   int left;
   int top;
@@ -1090,8 +1090,8 @@ int grayfilter(AVFrame *image) {
  * Moves a rectangular area of pixels to be centered above the centerX, centerY
  * coordinates.
  */
-void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
-                Mask mask) {
+void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
+                const Mask mask) {
   AVFrame *newimage;
 
   const int width = mask[RIGHT] - mask[LEFT] + 1;
@@ -1125,7 +1125,7 @@ void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
  * Moves a rectangular area of pixels to be centered inside a specified area
  * coordinates.
  */
-void alignMask(Mask mask, Mask outside,
+void alignMask(const Mask mask, const Mask outside,
                AVFrame *image) {
   AVFrame *newimage;
   int targetX;
@@ -1166,7 +1166,7 @@ void alignMask(Mask mask, Mask outside,
  *
  * @param x1..y2 area inside of which border is to be detected
  */
-static int detectBorderEdge(Mask outsideMask, int stepX, int stepY,
+static int detectBorderEdge(const Mask outsideMask, int stepX, int stepY,
                             int size, int threshold, AVFrame *image) {
   int left;
   int top;
@@ -1223,7 +1223,7 @@ static int detectBorderEdge(Mask outsideMask, int stepX, int stepY,
  * Detects a border of completely non-black pixels around the area
  * outsideBorder[LEFT],outsideBorder[TOP]-outsideBorder[RIGHT],outsideBorder[BOTTOM].
  */
-void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
+void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image) {
   border[LEFT] = outsideMask[LEFT];
   border[TOP] = outsideMask[TOP];
@@ -1256,7 +1256,7 @@ void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
 /**
  * Converts a border-tuple to a mask-tuple.
  */
-void borderToMask(int border[EDGES_COUNT], Mask mask,
+void borderToMask(const int border[EDGES_COUNT], Mask mask,
                   AVFrame *image) {
   mask[LEFT] = border[LEFT];
   mask[TOP] = border[TOP];
@@ -1273,7 +1273,7 @@ void borderToMask(int border[EDGES_COUNT], Mask mask,
  * Applies a border to the whole image. All pixels in the border range at the
  * edges of the sheet will be cleared.
  */
-void applyBorder(int border[EDGES_COUNT], AVFrame *image) {
+void applyBorder(const int border[EDGES_COUNT], AVFrame *image) {
   Mask mask;
 
   if (border[LEFT] != 0 || border[TOP] != 0 || border[RIGHT] != 0 ||

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -37,8 +37,7 @@ static inline bool masksOverlap(const Mask a, const Mask b) {
 /**
  * Tests if at least one mask in masks overlaps with m.
  */
-static bool masksOverlapAny(const Mask m,
-                            const Mask *masks, int masksCount) {
+static bool masksOverlapAny(const Mask m, const Mask *masks, int masksCount) {
   for (int i = 0; i < masksCount; i++) {
     if (masksOverlap(m, masks[i])) {
       return true;
@@ -702,8 +701,7 @@ void detectMasks(AVFrame *image) {
  * Permanently applies image masks. Each pixel which is not covered by at least
  * one mask is set to maskColor.
  */
-void applyMasks(Mask *masks, const int masksCount,
-                AVFrame *image) {
+void applyMasks(Mask *masks, const int masksCount, AVFrame *image) {
   if (masksCount <= 0) {
     return;
   }
@@ -727,8 +725,7 @@ void applyMasks(Mask *masks, const int masksCount,
  * Permanently wipes out areas of an images. Each pixel covered by a wipe-area
  * is set to wipeColor.
  */
-void applyWipes(Mask *area, int areaCount,
-                AVFrame *image) {
+void applyWipes(Mask *area, int areaCount, AVFrame *image) {
   for (int i = 0; i < areaCount; i++) {
     int count = 0;
     for (int y = area[i][TOP]; y <= area[i][BOTTOM]; y++) {
@@ -813,8 +810,8 @@ void flipRotate(int direction, AVFrame **image) {
  */
 static void blackfilterScan(int stepX, int stepY, int size, int dep,
                             unsigned int absBlackfilterScanThreshold,
-                            const Mask *exclude,
-                            int excludeCount, int intensity, AVFrame *image) {
+                            const Mask *exclude, int excludeCount,
+                            int intensity, AVFrame *image) {
   int left;
   int top;
   int right;
@@ -1124,8 +1121,7 @@ void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
  * Moves a rectangular area of pixels to be centered inside a specified area
  * coordinates.
  */
-void alignMask(const Mask mask, const Mask outside,
-               AVFrame *image) {
+void alignMask(const Mask mask, const Mask outside, AVFrame *image) {
   AVFrame *newimage;
   int targetX;
   int targetY;
@@ -1255,8 +1251,7 @@ void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
 /**
  * Converts a border-tuple to a mask-tuple.
  */
-void borderToMask(const int border[EDGES_COUNT], Mask mask,
-                  AVFrame *image) {
+void borderToMask(const int border[EDGES_COUNT], Mask mask, AVFrame *image) {
   mask[LEFT] = border[LEFT];
   mask[TOP] = border[TOP];
   mask[RIGHT] = image->width - border[RIGHT] - 1;

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -15,7 +15,6 @@
 #include <string.h>
 
 #include "imageprocess.h"
-#include "parse.h" //for maksOverlapAny
 #include "tools.h"
 #include "unpaper.h"
 

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libavutil/common.h>
+
 #include "imageprocess.h"
 #include "tools.h"
 #include "unpaper.h"
@@ -281,11 +283,8 @@ static int cubic(float x, int a, int b, int c, int d) {
                        (c - a +
                         x * (2.0f * a - 5.0f * b + 4.0f * c - d +
                              x * (3.0f * (b - c) + d - a)));
-  if (result > 255)
-    result = 255;
-  if (result < 0)
-    result = 0;
-  return result;
+
+  return av_clip_uint8(result);
 }
 
 /**

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -32,13 +32,11 @@ void shift(int shiftX, int shiftY, AVFrame **image);
 
 void detectMasks(AVFrame *image);
 
-void applyMasks(Mask *masks, const int maskCount,
-                AVFrame *image);
+void applyMasks(Mask *masks, const int maskCount, AVFrame *image);
 
 /* --- wiping ------------------------------------------------------------- */
 
-void applyWipes(Mask *area, int areaCount,
-                AVFrame *image);
+void applyWipes(Mask *area, int areaCount, AVFrame *image);
 
 /* --- mirroring ---------------------------------------------------------- */
 
@@ -74,7 +72,6 @@ void alignMask(const Mask mask, const Mask outside, AVFrame *image);
 void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image);
 
-void borderToMask(const int border[EDGES_COUNT], Mask mask,
-                  AVFrame *image);
+void borderToMask(const int border[EDGES_COUNT], Mask mask, AVFrame *image);
 
 void applyBorder(const int border[EDGES_COUNT], AVFrame *image);

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -16,7 +16,7 @@
 
 /* --- deskewing ---------------------------------------------------------- */
 
-float detectRotation(AVFrame *image, Mask mask);
+float detectRotation(AVFrame *image, const Mask mask);
 
 void rotate(const float radians, AVFrame *source, AVFrame *target);
 
@@ -66,15 +66,15 @@ int grayfilter(AVFrame *image);
 
 /* --- border-detection --------------------------------------------------- */
 
-void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
-                Mask mask);
+void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
+                const Mask mask);
 
-void alignMask(Mask mask, Mask outside, AVFrame *image);
+void alignMask(const Mask mask, const Mask outside, AVFrame *image);
 
-void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
+void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image);
 
-void borderToMask(int border[EDGES_COUNT], Mask mask,
+void borderToMask(const int border[EDGES_COUNT], Mask mask,
                   AVFrame *image);
 
-void applyBorder(int border[EDGES_COUNT], AVFrame *image);
+void applyBorder(const int border[EDGES_COUNT], AVFrame *image);

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -32,11 +32,11 @@ void shift(int shiftX, int shiftY, AVFrame **image);
 
 void detectMasks(AVFrame *image);
 
-void applyMasks(Mask *masks, const int maskCount, AVFrame *image);
+void applyMasks(const Mask *masks, const int maskCount, AVFrame *image);
 
 /* --- wiping ------------------------------------------------------------- */
 
-void applyWipes(Mask *area, int areaCount, AVFrame *image);
+void applyWipes(const Mask *area, int areaCount, AVFrame *image);
 
 /* --- mirroring ---------------------------------------------------------- */
 

--- a/parse.c
+++ b/parse.c
@@ -293,7 +293,7 @@ void parseMultiIndex(const char *optarg, struct MultiIndex *multiIndex) {
       }
 
       multiIndex->indexes[(multiIndex->count)++] = index;
-      if (c == '-') {   // range is specified: get range end
+      if (c == '-') { // range is specified: get range end
         if (components < 3) {
           errOutput("Invalid multi-index string \"%s\".", optarg);
         }

--- a/unpaper.c
+++ b/unpaper.c
@@ -25,8 +25,7 @@
 #include "version.h"
 
 #define WELCOME                                                                \
-  "unpaper " VERSION_STR                                                              \
-  "\n"                                                                         \
+  "unpaper " VERSION_STR "\n"                                                  \
   "License GPLv2: GNU GPL version 2.\n"                                        \
   "This is free software: you are free to change and redistribute it.\n"       \
   "There is NO WARRANTY, to the extent permitted by law.\n"


### PR DESCRIPTION
- Add venv/ to the list of ignored files.
- Use `const` specifiers for array parameters.
- Remove unused include.
- Update pre-commit hooks.
- Run clang-format appropriately.
- Use av_clip_uint8 instead of reinventing it.
- Apply two more const specifiers where masks are only consumed.
