### PR TITLE
Fix possibly uninitialized outputWildcard

### DIFF
--- a/unpaper.c
+++ b/unpaper.c
@@ -976,6 +976,8 @@ int main(int argc, char *argv[]) {
     // -------------------------------------------------------------------
 
     bool inputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    bool outputWildcard = false;
+
     for (int i = 0; i < inputCount; i++) {
       bool ins = isInMultiIndex(inputNr, insertBlank);
       bool repl = isInMultiIndex(inputNr, replaceBlank);
@@ -1025,7 +1027,7 @@ int main(int argc, char *argv[]) {
                           // it over the array boundary
       errOutput("not enough output files given.");
     }
-    bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
     for (int i = 0; i < outputCount; i++) {
       if (outputWildcard) {
         sprintf(outputFilesBuffer[i], argv[optind], outputNr++);


### PR DESCRIPTION
Fix possibly uninitialized outputWildcard

outputWildcard is initialized only after the first "goto sheet_end".
However, it is used after that sheet_end label.  Initialize the
variable first so that the compiler knows it is initialized, and then
set its actual value.
