### PR TITLE
layout: use the LAYOUTS type, not an int

### DIFF
--- a/unpaper.c
+++ b/unpaper.c
@@ -58,7 +58,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-int layout = LAYOUT_SINGLE;
+static int layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;

--- a/unpaper.c
+++ b/unpaper.c
@@ -976,6 +976,8 @@ int main(int argc, char *argv[]) {
     // -------------------------------------------------------------------
 
     bool inputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    bool outputWildcard = false;
+
     for (int i = 0; i < inputCount; i++) {
       bool ins = isInMultiIndex(inputNr, insertBlank);
       bool repl = isInMultiIndex(inputNr, replaceBlank);
@@ -1025,7 +1027,7 @@ int main(int argc, char *argv[]) {
                           // it over the array boundary
       errOutput("not enough output files given.");
     }
-    bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
     for (int i = 0; i < outputCount; i++) {
       if (outputWildcard) {
         sprintf(outputFilesBuffer[i], argv[optind], outputNr++);

--- a/unpaper.c
+++ b/unpaper.c
@@ -6,6 +6,7 @@
 
 /* --- The main program  -------------------------------------------------- */
 
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -58,7 +59,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-static int layout = LAYOUT_SINGLE;
+static LAYOUTS layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;
@@ -1188,12 +1189,17 @@ int main(int argc, char *argv[]) {
 
       if (verbose >= VERBOSE_MORE) {
         switch (layout) {
+        case LAYOUT_NONE:
+          printf("layout: none\n");
+          break;
         case LAYOUT_SINGLE:
           printf("layout: single\n");
           break;
         case LAYOUT_DOUBLE:
           printf("layout: double\n");
           break;
+        default:
+          assert(false); // unreachable
         }
 
         if (preRotate != 0) {

--- a/unpaper.h
+++ b/unpaper.h
@@ -35,7 +35,6 @@ extern float deskewScanRangeRad;
 extern float deskewScanStepRad;
 extern float deskewScanDeviationRad;
 
-extern int layout;
 extern int startSheet;
 extern int endSheet;
 extern int startInput;


### PR DESCRIPTION
layout: use the LAYOUTS type, not an int

Some consequences of this:

* The "switch (layout)" needs to handle all cases in the enum now.  I
added one for LAYOUT_NONE, which can occur when passing
"--layout=none".

* Also added a catch-all for unreachable cases in that switch(),
otherwise the compiler warns.  I'm not sure if you want to use
"assert(false)" as a construct for "unreachable code", but it seemed
appropriate.

* There is no test for --layout=none.
