### PR TITLE
Make test output write to the build directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 *~
-.vscode
+.vscode/
 _deps/
 _build/
 builddir/
 tests/__pycache__/
+venv/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ mileage may vary.
 Tests depend on `pytest` and `pillow`, which will be auto-detected by
 Meson.
 
+Development Hints
+-----------------
+
+The project includes configuration for [pre-commit](https://pre-commit.com/)
+which is integrated with GitHub Actions CI. If you're using git for
+devleopment, you can install it with
+`pip install pre-commit && pre-commit --install`.
+
+Using [Sapling](https://sapling-scm.com/) with this repository is possible
+and diffs can be reviewed as a stack.
+
 Further Information
 -------------------
 

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,9 @@ test(
     'pytest suite',
     python,
     args: [
-        '-m', 'pytest', meson.project_source_root() + '/tests/unpaper_tests.py'
+        '-m', 'pytest',
+        '--basetemp=' + meson.current_build_dir() + '/test_output/',
+        meson.project_source_root() + '/tests/unpaper_tests.py'
     ],
     env: [
         'TEST_IMGSRC_DIR=' + meson.project_source_root() + '/tests/source_images/',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: 0BSD
+
+meson >= 0.57
+ninja
+sphinx >= 3.4
+pytest
+pillow

--- a/unpaper.c
+++ b/unpaper.c
@@ -58,7 +58,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-int layout = LAYOUT_SINGLE;
+static int layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;

--- a/unpaper.c
+++ b/unpaper.c
@@ -976,6 +976,8 @@ int main(int argc, char *argv[]) {
     // -------------------------------------------------------------------
 
     bool inputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    bool outputWildcard = false;
+
     for (int i = 0; i < inputCount; i++) {
       bool ins = isInMultiIndex(inputNr, insertBlank);
       bool repl = isInMultiIndex(inputNr, replaceBlank);
@@ -1025,7 +1027,7 @@ int main(int argc, char *argv[]) {
                           // it over the array boundary
       errOutput("not enough output files given.");
     }
-    bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
     for (int i = 0; i < outputCount; i++) {
       if (outputWildcard) {
         sprintf(outputFilesBuffer[i], argv[optind], outputNr++);

--- a/unpaper.c
+++ b/unpaper.c
@@ -6,6 +6,7 @@
 
 /* --- The main program  -------------------------------------------------- */
 
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -58,7 +59,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-static int layout = LAYOUT_SINGLE;
+static LAYOUTS layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;
@@ -1188,12 +1189,17 @@ int main(int argc, char *argv[]) {
 
       if (verbose >= VERBOSE_MORE) {
         switch (layout) {
+        case LAYOUT_NONE:
+          printf("layout: none\n");
+          break;
         case LAYOUT_SINGLE:
           printf("layout: single\n");
           break;
         case LAYOUT_DOUBLE:
           printf("layout: double\n");
           break;
+        default:
+          assert(false); // unreachable
         }
 
         if (preRotate != 0) {

--- a/unpaper.h
+++ b/unpaper.h
@@ -35,7 +35,6 @@ extern float deskewScanRangeRad;
 extern float deskewScanStepRad;
 extern float deskewScanDeviationRad;
 
-extern int layout;
 extern int startSheet;
 extern int endSheet;
 extern int startInput;


### PR DESCRIPTION
Make test output write to the build directory.

This allows debugging test failures without having to find the right
temporary directory.

Unlike the default, passing the `basepath` means only the most recent
test run will be retained, that's okay.
