### PR TITLE
Separate primitive types and functions as well as math utilities.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 *~
-.vscode
+.vscode/
 _deps/
 _build/
 builddir/
 tests/__pycache__/
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v2.1.0
     hooks:
     - id: reuse
--   repo: https://github.com/doublify/pre-commit-clang-format
-    rev: 62302476d0da01515660132d76902359bed0f782
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
     hooks:
     -   id: clang-format

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ mileage may vary.
 Tests depend on `pytest` and `pillow`, which will be auto-detected by
 Meson.
 
+Development Hints
+-----------------
+
+The project includes configuration for [pre-commit](https://pre-commit.com/)
+which is integrated with GitHub Actions CI. If you're using git for
+devleopment, you can install it with
+`pip install pre-commit && pre-commit --install`.
+
+Using [Sapling](https://sapling-scm.com/) with this repository is possible
+and diffs can be reviewed as a stack.
+
 Further Information
 -------------------
 

--- a/file.c
+++ b/file.c
@@ -15,6 +15,7 @@
 #include <libavutil/avutil.h>
 #include <libavutil/opt.h>
 
+#include "imageprocess/blit.h"
 #include "tools.h"
 #include "unpaper.h"
 
@@ -169,7 +170,8 @@ void saveImage(char *filename, AVFrame *input, int outputPixFmt) {
 
   if (input->format != outputPixFmt) {
     initImage(&output, input->width, input->height, outputPixFmt, -1);
-    copyImageArea(0, 0, input->width, input->height, input, 0, 0, output);
+    copy_rectangle(input, output, RECT_FULL_IMAGE, POINT_ORIGIN,
+                   absBlackThreshold);
   }
 
   codec = avcodec_find_encoder(output_codec);

--- a/file.c
+++ b/file.c
@@ -139,7 +139,7 @@ void saveImage(char *filename, AVFrame *input, int outputPixFmt) {
   char errbuff[1024];
 
   if (avformat_alloc_output_context2(&out_ctx, NULL, "image2", filename) < 0 ||
-    out_ctx == NULL) {
+      out_ctx == NULL) {
     errOutput("unable to allocate output context.");
   }
 

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -1114,9 +1114,7 @@ void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
     wipe_rectangle(
         image,
         (Rectangle){{{mask[LEFT], mask[TOP]}, {mask[RIGHT], mask[BOTTOM]}}},
-        (Pixel){(sheetBackground >> 16) & 0xff, (sheetBackground >> 8) & 0xff,
-                sheetBackground & 0xff},
-        absBlackThreshold);
+        sheetBackgroundPixel, absBlackThreshold);
     copy_rectangle(newimage, image, RECT_FULL_IMAGE, (Point){targetX, targetY},
                    absBlackThreshold);
     av_frame_free(&newimage);
@@ -1168,9 +1166,7 @@ void alignMask(const Mask mask, const Mask outside, AVFrame *image) {
   wipe_rectangle(
       image,
       (Rectangle){{{mask[LEFT], mask[TOP]}, {mask[RIGHT], mask[BOTTOM]}}},
-      (Pixel){(sheetBackground >> 16) & 0xff, (sheetBackground >> 8) & 0xff,
-              sheetBackground & 0xff},
-      absBlackThreshold);
+      sheetBackgroundPixel, absBlackThreshold);
   copy_rectangle(newimage, image, RECT_FULL_IMAGE, (Point){targetX, targetY},
                  absBlackThreshold);
   av_frame_free(&newimage);

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -23,7 +23,7 @@
  * image processing functions                                               *
  ****************************************************************************/
 
-static inline bool inMask(int x, int y, Mask mask) {
+static inline bool inMask(int x, int y, const Mask mask) {
   return (x >= mask[LEFT]) && (x <= mask[RIGHT]) && (y >= mask[TOP]) &&
          (y <= mask[BOTTOM]);
 }
@@ -31,15 +31,15 @@ static inline bool inMask(int x, int y, Mask mask) {
 /**
  * Tests if masks a and b overlap.
  */
-static inline bool masksOverlap(Mask a, Mask b) {
+static inline bool masksOverlap(const Mask a, const Mask b) {
   return (inMask(a[LEFT], a[TOP], b) || inMask(a[RIGHT], a[BOTTOM], b));
 }
 
 /**
  * Tests if at least one mask in masks overlaps with m.
  */
-static bool masksOverlapAny(Mask m,
-                            Mask *masks, int masksCount) {
+static bool masksOverlapAny(const Mask m,
+                            const Mask *masks, int masksCount) {
   for (int i = 0; i < masksCount; i++) {
     if (masksOverlap(m, masks[i])) {
       return true;
@@ -61,7 +61,7 @@ static bool masksOverlapAny(Mask m,
  * this is negative for negative radians.
  */
 static int detectEdgeRotationPeak(float m, int shiftX, int shiftY,
-                                  AVFrame *image, Mask mask) {
+                                  AVFrame *image, const Mask mask) {
   int width = mask[RIGHT] - mask[LEFT] + 1;
   int height = mask[BOTTOM] - mask[TOP] + 1;
   int mid;
@@ -167,7 +167,7 @@ static int detectEdgeRotationPeak(float m, int shiftX, int shiftY,
  * is non-zero, and what sign this shifting value has.
  */
 static float detectEdgeRotation(int shiftX, int shiftY, AVFrame *image,
-                                Mask mask) {
+                                const Mask mask) {
   // either shiftX or shiftY is 0, the other value is -i|+i
   // depending on shiftX/shiftY the start edge for shifting is determined
   int maxPeak = 0;
@@ -194,7 +194,7 @@ static float detectEdgeRotation(int shiftX, int shiftY, AVFrame *image,
  * the horizontal or vertical edges of the area specified by left, top, right,
  * bottom.
  */
-float detectRotation(AVFrame *image, Mask mask) {
+float detectRotation(AVFrame *image, const Mask mask) {
   float rotation[4];
   int count = 0;
   float total;
@@ -584,12 +584,12 @@ static int detectEdge(int startX, int startY, int shiftX, int shiftY,
  * no mask could be detected
  */
 static bool detectMask(int startX, int startY, int maskScanDirections,
-                       int maskScanSize[DIRECTIONS_COUNT],
-                       int maskScanDepth[DIRECTIONS_COUNT],
-                       int maskScanStep[DIRECTIONS_COUNT],
-                       float maskScanThreshold[DIRECTIONS_COUNT],
-                       int maskScanMinimum[DIMENSIONS_COUNT],
-                       int maskScanMaximum[DIMENSIONS_COUNT], int *left,
+                       const int maskScanSize[DIRECTIONS_COUNT],
+                       const int maskScanDepth[DIRECTIONS_COUNT],
+                       const int maskScanStep[DIRECTIONS_COUNT],
+                       const float maskScanThreshold[DIRECTIONS_COUNT],
+                       const int maskScanMinimum[DIMENSIONS_COUNT],
+                       const int maskScanMaximum[DIMENSIONS_COUNT], int *left,
                        int *top, int *right, int *bottom, AVFrame *image) {
   int width;
   int height;
@@ -814,7 +814,7 @@ void flipRotate(int direction, AVFrame **image) {
  */
 static void blackfilterScan(int stepX, int stepY, int size, int dep,
                             unsigned int absBlackfilterScanThreshold,
-                            Mask *exclude,
+                            const Mask *exclude,
                             int excludeCount, int intensity, AVFrame *image) {
   int left;
   int top;
@@ -1090,8 +1090,8 @@ int grayfilter(AVFrame *image) {
  * Moves a rectangular area of pixels to be centered above the centerX, centerY
  * coordinates.
  */
-void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
-                Mask mask) {
+void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
+                const Mask mask) {
   AVFrame *newimage;
 
   const int width = mask[RIGHT] - mask[LEFT] + 1;
@@ -1125,7 +1125,7 @@ void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
  * Moves a rectangular area of pixels to be centered inside a specified area
  * coordinates.
  */
-void alignMask(Mask mask, Mask outside,
+void alignMask(const Mask mask, const Mask outside,
                AVFrame *image) {
   AVFrame *newimage;
   int targetX;
@@ -1166,7 +1166,7 @@ void alignMask(Mask mask, Mask outside,
  *
  * @param x1..y2 area inside of which border is to be detected
  */
-static int detectBorderEdge(Mask outsideMask, int stepX, int stepY,
+static int detectBorderEdge(const Mask outsideMask, int stepX, int stepY,
                             int size, int threshold, AVFrame *image) {
   int left;
   int top;
@@ -1223,7 +1223,7 @@ static int detectBorderEdge(Mask outsideMask, int stepX, int stepY,
  * Detects a border of completely non-black pixels around the area
  * outsideBorder[LEFT],outsideBorder[TOP]-outsideBorder[RIGHT],outsideBorder[BOTTOM].
  */
-void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
+void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image) {
   border[LEFT] = outsideMask[LEFT];
   border[TOP] = outsideMask[TOP];
@@ -1256,7 +1256,7 @@ void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
 /**
  * Converts a border-tuple to a mask-tuple.
  */
-void borderToMask(int border[EDGES_COUNT], Mask mask,
+void borderToMask(const int border[EDGES_COUNT], Mask mask,
                   AVFrame *image) {
   mask[LEFT] = border[LEFT];
   mask[TOP] = border[TOP];
@@ -1273,7 +1273,7 @@ void borderToMask(int border[EDGES_COUNT], Mask mask,
  * Applies a border to the whole image. All pixels in the border range at the
  * edges of the sheet will be cleared.
  */
-void applyBorder(int border[EDGES_COUNT], AVFrame *image) {
+void applyBorder(const int border[EDGES_COUNT], AVFrame *image) {
   Mask mask;
 
   if (border[LEFT] != 0 || border[TOP] != 0 || border[RIGHT] != 0 ||

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -703,8 +703,7 @@ void detectMasks(AVFrame *image) {
  * Permanently applies image masks. Each pixel which is not covered by at least
  * one mask is set to maskColor.
  */
-void applyMasks(Mask *masks, const int masksCount,
-                AVFrame *image) {
+void applyMasks(const Mask *masks, const int masksCount, AVFrame *image) {
   if (masksCount <= 0) {
     return;
   }
@@ -728,8 +727,7 @@ void applyMasks(Mask *masks, const int masksCount,
  * Permanently wipes out areas of an images. Each pixel covered by a wipe-area
  * is set to wipeColor.
  */
-void applyWipes(Mask *area, int areaCount,
-                AVFrame *image) {
+void applyWipes(const Mask *area, int areaCount, AVFrame *image) {
   for (int i = 0; i < areaCount; i++) {
     int count = 0;
     for (int y = area[i][TOP]; y <= area[i][BOTTOM]; y++) {

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -37,8 +37,7 @@ static inline bool masksOverlap(const Mask a, const Mask b) {
 /**
  * Tests if at least one mask in masks overlaps with m.
  */
-static bool masksOverlapAny(const Mask m,
-                            const Mask *masks, int masksCount) {
+static bool masksOverlapAny(const Mask m, const Mask *masks, int masksCount) {
   for (int i = 0; i < masksCount; i++) {
     if (masksOverlap(m, masks[i])) {
       return true;
@@ -811,8 +810,8 @@ void flipRotate(int direction, AVFrame **image) {
  */
 static void blackfilterScan(int stepX, int stepY, int size, int dep,
                             unsigned int absBlackfilterScanThreshold,
-                            const Mask *exclude,
-                            int excludeCount, int intensity, AVFrame *image) {
+                            const Mask *exclude, int excludeCount,
+                            int intensity, AVFrame *image) {
   int left;
   int top;
   int right;
@@ -1122,8 +1121,7 @@ void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
  * Moves a rectangular area of pixels to be centered inside a specified area
  * coordinates.
  */
-void alignMask(const Mask mask, const Mask outside,
-               AVFrame *image) {
+void alignMask(const Mask mask, const Mask outside, AVFrame *image) {
   AVFrame *newimage;
   int targetX;
   int targetY;
@@ -1253,8 +1251,7 @@ void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
 /**
  * Converts a border-tuple to a mask-tuple.
  */
-void borderToMask(const int border[EDGES_COUNT], Mask mask,
-                  AVFrame *image) {
+void borderToMask(const int border[EDGES_COUNT], Mask mask, AVFrame *image) {
   mask[LEFT] = border[LEFT];
   mask[TOP] = border[TOP];
   mask[RIGHT] = image->width - border[RIGHT] - 1;

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -15,7 +15,6 @@
 #include <string.h>
 
 #include "imageprocess.h"
-#include "parse.h" //for maksOverlapAny
 #include "tools.h"
 #include "unpaper.h"
 

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libavutil/common.h>
+
 #include "imageprocess.h"
 #include "tools.h"
 #include "unpaper.h"
@@ -281,11 +283,8 @@ static int cubic(float x, int a, int b, int c, int d) {
                        (c - a +
                         x * (2.0f * a - 5.0f * b + 4.0f * c - d +
                              x * (3.0f * (b - c) + d - a)));
-  if (result > 255)
-    result = 255;
-  if (result < 0)
-    result = 0;
-  return result;
+
+  return av_clip_uint8(result);
 }
 
 /**

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -72,7 +72,6 @@ void alignMask(const Mask mask, const Mask outside, AVFrame *image);
 void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image);
 
-void borderToMask(const int border[EDGES_COUNT], Mask mask,
-                  AVFrame *image);
+void borderToMask(const int border[EDGES_COUNT], Mask mask, AVFrame *image);
 
 void applyBorder(const int border[EDGES_COUNT], AVFrame *image);

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -16,7 +16,7 @@
 
 /* --- deskewing ---------------------------------------------------------- */
 
-float detectRotation(AVFrame *image, Mask mask);
+float detectRotation(AVFrame *image, const Mask mask);
 
 void rotate(const float radians, AVFrame *source, AVFrame *target);
 
@@ -66,15 +66,15 @@ int grayfilter(AVFrame *image);
 
 /* --- border-detection --------------------------------------------------- */
 
-void centerMask(AVFrame *image, int center[COORDINATES_COUNT],
-                Mask mask);
+void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
+                const Mask mask);
 
-void alignMask(Mask mask, Mask outside, AVFrame *image);
+void alignMask(const Mask mask, const Mask outside, AVFrame *image);
 
-void detectBorder(int border[EDGES_COUNT], Mask outsideMask,
+void detectBorder(int border[EDGES_COUNT], const Mask outsideMask,
                   AVFrame *image);
 
-void borderToMask(int border[EDGES_COUNT], Mask mask,
+void borderToMask(const int border[EDGES_COUNT], Mask mask,
                   AVFrame *image);
 
-void applyBorder(int border[EDGES_COUNT], AVFrame *image);
+void applyBorder(const int border[EDGES_COUNT], AVFrame *image);

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -32,13 +32,11 @@ void shift(int shiftX, int shiftY, AVFrame **image);
 
 void detectMasks(AVFrame *image);
 
-void applyMasks(Mask *masks, const int maskCount,
-                AVFrame *image);
+void applyMasks(const Mask *masks, const int maskCount, AVFrame *image);
 
 /* --- wiping ------------------------------------------------------------- */
 
-void applyWipes(Mask *area, int areaCount,
-                AVFrame *image);
+void applyWipes(const Mask *area, int areaCount, AVFrame *image);
 
 /* --- mirroring ---------------------------------------------------------- */
 

--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "blit.h"
+
+#define max(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a > _b ? _a : _b;                                                         \
+  })
+
+#define min(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a < _b ? _a : _b;                                                         \
+  })
+
+static Rectangle normalize_rectangle(Rectangle input) {
+  return (Rectangle){
+      .vertex =
+          {
+              {
+                  .x = min(input.vertex[0].x, input.vertex[1].x),
+                  .y = min(input.vertex[0].y, input.vertex[1].y),
+              },
+              {
+                  .x = max(input.vertex[0].x, input.vertex[1].x),
+                  .y = max(input.vertex[0].y, input.vertex[1].y),
+              },
+          },
+  };
+}
+
+static Rectangle clip_rectangle(AVFrame *image, Rectangle area) {
+  Rectangle normal_area = normalize_rectangle(area);
+
+  return (Rectangle){
+      .vertex =
+          {
+              {
+                  .x = max(normal_area.vertex[0].x, 0),
+                  .y = max(normal_area.vertex[0].y, 0),
+              },
+              {
+                  .x = min(normal_area.vertex[1].x, (image->width - 1)),
+                  .y = min(normal_area.vertex[1].y, (image->height - 1)),
+              },
+          },
+  };
+}
+
+/**
+ * Wipe a rectangular area of pixels with the defined color.
+ * @return The number of pixels actually changed.
+ */
+int wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
+                   uint8_t abs_black_threshold) {
+  int count = 0;
+
+  Rectangle area = clip_rectangle(image, input_area);
+
+  for (uint32_t y = area.vertex[0].y; y <= area.vertex[1].y; y++) {
+    for (uint32_t x = area.vertex[0].x; x <= area.vertex[1].x; x++) {
+      if (set_pixel(image, (Point){x, y}, color, abs_black_threshold)) {
+        count++;
+      }
+    }
+  }
+
+  return count;
+}

--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -18,6 +18,10 @@
     _a < _b ? _a : _b;                                                         \
   })
 
+#define scan_rect(area)                                                        \
+  for (int32_t y = area.vertex[0].y; y <= area.vertex[1].y; y++)               \
+    for (int32_t x = area.vertex[0].x; x <= area.vertex[1].x; x++)
+
 static Rectangle normalize_rectangle(Rectangle input) {
   return (Rectangle){
       .vertex =
@@ -52,23 +56,85 @@ static Rectangle clip_rectangle(AVFrame *image, Rectangle area) {
   };
 }
 
+static uint64_t count_pixels(Rectangle area) {
+  return ((abs(area.vertex[0].x - area.vertex[1].x) + 1) *
+          (abs(area.vertex[0].y - area.vertex[1].y) + 1));
+}
+
 /**
  * Wipe a rectangular area of pixels with the defined color.
  * @return The number of pixels actually changed.
  */
-int wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
-                   uint8_t abs_black_threshold) {
-  int count = 0;
+uint64_t wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
+                        uint8_t abs_black_threshold) {
+  uint64_t count = 0;
 
   Rectangle area = clip_rectangle(image, input_area);
 
-  for (uint32_t y = area.vertex[0].y; y <= area.vertex[1].y; y++) {
-    for (uint32_t x = area.vertex[0].x; x <= area.vertex[1].x; x++) {
-      if (set_pixel(image, (Point){x, y}, color, abs_black_threshold)) {
-        count++;
-      }
+  scan_rect(area) {
+    if (set_pixel(image, (Point){x, y}, color, abs_black_threshold)) {
+      count++;
     }
   }
 
   return count;
+}
+
+void copy_rectangle(AVFrame *source, AVFrame *target, Rectangle source_area,
+                    Point target_coords, uint8_t abs_black_threshold) {
+  Rectangle area = clip_rectangle(source, source_area);
+
+  // naive but generic implementation
+  for (int32_t sY = area.vertex[0].y, tY = target_coords.y;
+       sY <= area.vertex[1].y; sY++, tY++) {
+    for (int32_t sX = area.vertex[0].x, tX = target_coords.x;
+         sX <= area.vertex[1].x; sX++, tX++) {
+      set_pixel(target, (Point){tX, tY}, get_pixel(source, (Point){sX, sY}),
+                abs_black_threshold);
+    }
+  }
+}
+
+/**
+ * Returns the average brightness of a rectangular area.
+ */
+uint8_t inverse_brightness_rect(AVFrame *image, Rectangle input_area) {
+  uint64_t grayscale = 0;
+
+  Rectangle area = clip_rectangle(image, input_area);
+  uint64_t count = count_pixels(area);
+
+  scan_rect(area) { grayscale += get_pixel_grayscale(image, (Point){x, y}); }
+
+  return 0xFF - (grayscale / count);
+}
+
+/**
+ * Returns the inverse average lightness of a rectangular area.
+ */
+uint8_t inverse_lightness_rect(AVFrame *image, Rectangle input_area) {
+  uint64_t lightness = 0;
+
+  Rectangle area = clip_rectangle(image, input_area);
+  uint64_t count = count_pixels(area);
+
+  scan_rect(area) { lightness += get_pixel_lightness(image, (Point){x, y}); }
+
+  return 0xFF - (lightness / count);
+}
+
+/**
+ * Returns the average darkness of a rectangular area.
+ */
+uint8_t darkness_rect(AVFrame *image, Rectangle input_area) {
+  uint64_t darkness = 0;
+
+  Rectangle area = clip_rectangle(image, input_area);
+  uint64_t count = count_pixels(area);
+
+  scan_rect(area) {
+    darkness += get_pixel_darkness_inverse(image, (Point){x, y});
+  }
+
+  return 0xFF - (darkness / count);
 }

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -4,13 +4,10 @@
 
 #pragma once
 
-#include "pixel.h"
+#include <libavutil/frame.h>
+#include <stdint.h>
 
-typedef struct {
-  Point vertex[2];
-} Rectangle;
-
-static const Rectangle RECT_FULL_IMAGE = {{POINT_ORIGIN, POINT_INFINITY}};
+#include "primitives.h"
 
 uint64_t wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
                         uint8_t abs_black_threshold);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -10,5 +10,12 @@ typedef struct {
   Point vertex[2];
 } Rectangle;
 
-int wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
-                   uint8_t abs_black_threshold);
+static const Rectangle RECT_FULL_IMAGE = {{POINT_ORIGIN, POINT_INFINITY}};
+
+uint64_t wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
+                        uint8_t abs_black_threshold);
+void copy_rectangle(AVFrame *source, AVFrame *target, Rectangle source_area,
+                    Point target_coords, uint8_t abs_black_threshold);
+uint8_t inverse_brightness_rect(AVFrame *image, Rectangle input_area);
+uint8_t inverse_lightness_rect(AVFrame *image, Rectangle input_area);
+uint8_t darkness_rect(AVFrame *image, Rectangle input_area);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "pixel.h"
+
+typedef struct {
+  Point vertex[2];
+} Rectangle;
+
+int wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
+                   uint8_t abs_black_threshold);

--- a/imageprocess/math_util.h
+++ b/imageprocess/math_util.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#define max(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a > _b ? _a : _b;                                                         \
+  })
+
+#define min(a, b)                                                              \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    _a < _b ? _a : _b;                                                         \
+  })
+
+#define max3(a, b, c)                                                          \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    __typeof__(c) _c = (c);                                                    \
+    (_a > _b ? (_a > _c ? _a : _c) : (_b > _c ? _b : _c));                     \
+  })
+
+#define min3(a, b, c)                                                          \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    __typeof__(c) _c = (c);                                                    \
+    (_a < _b ? (_a < _c ? _a : _c) : (_b < _c ? _b : _c));                     \
+  })

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <libavutil/avutil.h>
+#include <libavutil/frame.h>
+#include <libavutil/pixfmt.h>
+
+#include "pixel.h"
+
+void errOutput(const char *fmt, ...);
+
+#define WHITE 0xFF
+#define BLACK 0x00
+
+#define max3(a, b, c)                                                          \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    __typeof__(c) _c = (c);                                                    \
+    (_a > _b ? (_a > _c ? _a : _c) : (_b > _c ? _b : _c));                     \
+  })
+
+#define min3(a, b, c)                                                          \
+  ({                                                                           \
+    __typeof__(a) _a = (a);                                                    \
+    __typeof__(b) _b = (b);                                                    \
+    __typeof__(c) _c = (c);                                                    \
+    (_a < _b ? (_a < _c ? _a : _c) : (_b < _c ? _b : _c));                     \
+  })
+
+static inline uint8_t pixel_grayscale(Pixel pixel) {
+  return (pixel.r + pixel.g + pixel.b) / 3;
+}
+
+static Pixel get_pixel_components(AVFrame *image, Point coords,
+                                  uint8_t defval) {
+  Pixel pixel = {defval, defval, defval};
+  uint8_t *pix;
+
+  if ((coords.x < 0) || (coords.x >= image->width) || (coords.y < 0) ||
+      (coords.y >= image->height)) {
+    return pixel;
+  }
+
+  switch (image->format) {
+  case AV_PIX_FMT_GRAY8:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x);
+    pixel.r = pixel.g = pixel.b = *pix;
+    break;
+  case AV_PIX_FMT_Y400A:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x * 2);
+    pixel.r = pixel.g = pixel.b = *pix;
+    break;
+  case AV_PIX_FMT_RGB24:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x * 3);
+    pixel.r = pix[0];
+    pixel.g = pix[1];
+    pixel.b = pix[2];
+    break;
+  case AV_PIX_FMT_MONOWHITE:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
+    if (*pix & (128 >> (coords.x % 8)))
+      pixel.r = pixel.g = pixel.b = BLACK;
+    else
+      pixel.r = pixel.g = pixel.b = WHITE;
+    break;
+  case AV_PIX_FMT_MONOBLACK:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
+    if (*pix & (128 >> (coords.x % 8)))
+      pixel.r = pixel.g = pixel.b = WHITE;
+    else
+      pixel.r = pixel.g = pixel.b = BLACK;
+    break;
+  default:
+    errOutput("unknown pixel format.");
+  }
+
+  return pixel;
+}
+
+/* Returns the color or grayscale value of a single pixel.
+ * Always returns a color-compatible value (which may be interpreted as 8-bit
+ * grayscale)
+ *
+ * @return color or grayscale-value of the requested pixel, or WHITE if the
+ * coordinates are outside the image
+ */
+Pixel get_pixel(AVFrame *image, Point coords) {
+  return get_pixel_components(image, coords, WHITE);
+}
+
+/**
+ * Returns the grayscale (=brightness) value of a single pixel.
+ *
+ * @return grayscale-value of the requested pixel, or WHITE if the coordinates
+ * are outside the image
+ */
+uint8_t get_pixel_grayscale(AVFrame *image, Point coords) {
+  return pixel_grayscale(get_pixel(image, coords));
+}
+
+/**
+ * Returns the 'lightness' value of a single pixel. For color images, this
+ * value denotes the minimum brightness of a single color-component in the
+ * total color, which means that any color is considered 'dark' which has
+ * either the red, the green or the blue component (or, of course, several
+ * of them) set to a high value. In some way, this is a measure how close a
+ * color is to white.
+ * For grayscale images, this value is equal to the pixel brightness.
+ *
+ * @return lightness-value (the higher, the lighter) of the requested pixel, or
+ * WHITE if the coordinates are outside the image
+ */
+uint8_t get_pixel_lightness(AVFrame *image, Point coords) {
+  Pixel p = get_pixel_components(image, coords, WHITE);
+  return min3(p.r, p.g, p.b);
+}
+
+/**
+ * Returns the 'inverse-darkness' value of a single pixel. For color images,
+ * this value denotes the maximum brightness of a single color-component in the
+ * total color, which means that any color is considered 'light' which has
+ * either the red, the green or the blue component (or, of course, several
+ * of them) set to a high value. In some way, this is a measure how far away a
+ * color is to black.
+ * For grayscale images, this value is equal to the pixel brightness.
+ *
+ * @return inverse-darkness-value (the LOWER, the darker) of the requested
+ * pixel, or WHITE if the coordinates are outside the image
+ */
+uint8_t get_pixel_darkness_inverse(AVFrame *image, Point coords) {
+  Pixel p = get_pixel_components(image, coords, WHITE);
+  return max3(p.r, p.g, p.b);
+}
+
+/**
+ * Sets the color/grayscale value of a single pixel.
+ *
+ * @return true if the pixel has been changed, false if the original color was
+ * the one to set
+ */
+bool set_pixel(AVFrame *image, Point coords, Pixel pixel,
+               uint8_t abs_black_threshold) {
+  uint8_t *pix;
+
+  if ((coords.x < 0) || (coords.x >= image->width) || (coords.y < 0) ||
+      (coords.y >= image->height)) {
+    return false; // nop
+  }
+
+  uint8_t pixelbw =
+      pixel_grayscale(pixel) < abs_black_threshold ? BLACK : WHITE;
+
+  switch (image->format) {
+  case AV_PIX_FMT_GRAY8:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x);
+    *pix = pixel_grayscale(pixel);
+    break;
+  case AV_PIX_FMT_Y400A:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x * 2);
+    pix[0] = pixel_grayscale(pixel);
+    pix[1] = 0xFF; // no alpha.
+    break;
+  case AV_PIX_FMT_RGB24:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x * 3);
+    pix[0] = pixel.r;
+    pix[1] = pixel.g;
+    pix[2] = pixel.b;
+    break;
+  case AV_PIX_FMT_MONOWHITE:
+    pixelbw = ~pixelbw; // reverse compared to following case
+  case AV_PIX_FMT_MONOBLACK:
+    pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
+    if (pixelbw == WHITE) {
+      *pix = *pix | (128 >> (coords.x % 8));
+    } else if (pixelbw == BLACK) {
+      *pix = *pix & ~(128 >> (coords.x % 8));
+    }
+    break;
+  default:
+    errOutput("unknown pixel format.");
+  }
+  return true;
+}

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -13,8 +13,8 @@
 
 void errOutput(const char *fmt, ...);
 
-#define WHITE 0xFF
-#define BLACK 0x00
+#define WHITE_COMPONENT 0xFF
+#define BLACK_COMPONENT 0x00
 
 #define max3(a, b, c)                                                          \
   ({                                                                           \
@@ -64,16 +64,16 @@ static Pixel get_pixel_components(AVFrame *image, Point coords,
   case AV_PIX_FMT_MONOWHITE:
     pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
     if (*pix & (128 >> (coords.x % 8)))
-      pixel.r = pixel.g = pixel.b = BLACK;
+      pixel.r = pixel.g = pixel.b = BLACK_COMPONENT;
     else
-      pixel.r = pixel.g = pixel.b = WHITE;
+      pixel.r = pixel.g = pixel.b = WHITE_COMPONENT;
     break;
   case AV_PIX_FMT_MONOBLACK:
     pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
     if (*pix & (128 >> (coords.x % 8)))
-      pixel.r = pixel.g = pixel.b = WHITE;
+      pixel.r = pixel.g = pixel.b = WHITE_COMPONENT;
     else
-      pixel.r = pixel.g = pixel.b = BLACK;
+      pixel.r = pixel.g = pixel.b = BLACK_COMPONENT;
     break;
   default:
     errOutput("unknown pixel format.");
@@ -86,18 +86,18 @@ static Pixel get_pixel_components(AVFrame *image, Point coords,
  * Always returns a color-compatible value (which may be interpreted as 8-bit
  * grayscale)
  *
- * @return color or grayscale-value of the requested pixel, or WHITE if the
- * coordinates are outside the image
+ * @return color or grayscale-value of the requested pixel, or WHITE_COMPONENT
+ * if the coordinates are outside the image
  */
 Pixel get_pixel(AVFrame *image, Point coords) {
-  return get_pixel_components(image, coords, WHITE);
+  return get_pixel_components(image, coords, WHITE_COMPONENT);
 }
 
 /**
  * Returns the grayscale (=brightness) value of a single pixel.
  *
- * @return grayscale-value of the requested pixel, or WHITE if the coordinates
- * are outside the image
+ * @return grayscale-value of the requested pixel, or WHITE_COMPONENT if the
+ * coordinates are outside the image
  */
 uint8_t get_pixel_grayscale(AVFrame *image, Point coords) {
   return pixel_grayscale(get_pixel(image, coords));
@@ -113,10 +113,10 @@ uint8_t get_pixel_grayscale(AVFrame *image, Point coords) {
  * For grayscale images, this value is equal to the pixel brightness.
  *
  * @return lightness-value (the higher, the lighter) of the requested pixel, or
- * WHITE if the coordinates are outside the image
+ * WHITE_COMPONENT if the coordinates are outside the image
  */
 uint8_t get_pixel_lightness(AVFrame *image, Point coords) {
-  Pixel p = get_pixel_components(image, coords, WHITE);
+  Pixel p = get_pixel_components(image, coords, WHITE_COMPONENT);
   return min3(p.r, p.g, p.b);
 }
 
@@ -130,10 +130,10 @@ uint8_t get_pixel_lightness(AVFrame *image, Point coords) {
  * For grayscale images, this value is equal to the pixel brightness.
  *
  * @return inverse-darkness-value (the LOWER, the darker) of the requested
- * pixel, or WHITE if the coordinates are outside the image
+ * pixel, or WHITE_COMPONENT if the coordinates are outside the image
  */
 uint8_t get_pixel_darkness_inverse(AVFrame *image, Point coords) {
-  Pixel p = get_pixel_components(image, coords, WHITE);
+  Pixel p = get_pixel_components(image, coords, WHITE_COMPONENT);
   return max3(p.r, p.g, p.b);
 }
 
@@ -152,8 +152,9 @@ bool set_pixel(AVFrame *image, Point coords, Pixel pixel,
     return false; // nop
   }
 
-  uint8_t pixelbw =
-      pixel_grayscale(pixel) < abs_black_threshold ? BLACK : WHITE;
+  uint8_t pixelbw = pixel_grayscale(pixel) < abs_black_threshold
+                        ? BLACK_COMPONENT
+                        : WHITE_COMPONENT;
 
   switch (image->format) {
   case AV_PIX_FMT_GRAY8:
@@ -175,9 +176,9 @@ bool set_pixel(AVFrame *image, Point coords, Pixel pixel,
     pixelbw = ~pixelbw; // reverse compared to following case
   case AV_PIX_FMT_MONOBLACK:
     pix = image->data[0] + (coords.y * image->linesize[0] + coords.x / 8);
-    if (pixelbw == WHITE) {
+    if (pixelbw == WHITE_COMPONENT) {
       *pix = *pix | (128 >> (coords.x % 8));
-    } else if (pixelbw == BLACK) {
+    } else if (pixelbw == BLACK_COMPONENT) {
       *pix = *pix & ~(128 >> (coords.x % 8));
     }
     break;

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -9,28 +9,13 @@
 #include <libavutil/frame.h>
 #include <libavutil/pixfmt.h>
 
-#include "pixel.h"
+#include "imageprocess/math_util.h"
+#include "imageprocess/pixel.h"
 
 void errOutput(const char *fmt, ...);
 
 #define WHITE_COMPONENT 0xFF
 #define BLACK_COMPONENT 0x00
-
-#define max3(a, b, c)                                                          \
-  ({                                                                           \
-    __typeof__(a) _a = (a);                                                    \
-    __typeof__(b) _b = (b);                                                    \
-    __typeof__(c) _c = (c);                                                    \
-    (_a > _b ? (_a > _c ? _a : _c) : (_b > _c ? _b : _c));                     \
-  })
-
-#define min3(a, b, c)                                                          \
-  ({                                                                           \
-    __typeof__(a) _a = (a);                                                    \
-    __typeof__(b) _b = (b);                                                    \
-    __typeof__(c) _c = (c);                                                    \
-    (_a < _b ? (_a < _c ? _a : _c) : (_b < _c ? _b : _c));                     \
-  })
 
 static inline uint8_t pixel_grayscale(Pixel pixel) {
   return (pixel.r + pixel.g + pixel.b) / 3;

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -20,6 +20,8 @@ typedef struct {
   uint8_t b;
 } Pixel;
 
+static const Pixel PIXEL_WHITE = {0xFF, 0xFF, 0xFF};
+
 Pixel get_pixel(AVFrame *image, Point coords);
 uint8_t get_pixel_grayscale(AVFrame *image, Point coords);
 uint8_t get_pixel_lightness(AVFrame *image, Point coords);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <libavutil/frame.h>
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} Point;
+
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} Pixel;
+
+Pixel get_pixel(AVFrame *image, Point coords);
+uint8_t get_pixel_grayscale(AVFrame *image, Point coords);
+uint8_t get_pixel_lightness(AVFrame *image, Point coords);
+uint8_t get_pixel_darkness_inverse(AVFrame *image, Point coords);
+bool set_pixel(AVFrame *image, Point coords, Pixel pixel,
+               uint8_t abs_black_threshold);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -9,21 +9,7 @@
 
 #include <libavutil/frame.h>
 
-typedef struct {
-  int32_t x;
-  int32_t y;
-} Point;
-
-static const Point POINT_ORIGIN = {0, 0};
-static const Point POINT_INFINITY = {INT32_MAX, INT32_MAX};
-
-typedef struct {
-  uint8_t r;
-  uint8_t g;
-  uint8_t b;
-} Pixel;
-
-static const Pixel PIXEL_WHITE = {0xFF, 0xFF, 0xFF};
+#include "imageprocess/primitives.h"
 
 Pixel get_pixel(AVFrame *image, Point coords);
 uint8_t get_pixel_grayscale(AVFrame *image, Point coords);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -14,6 +14,9 @@ typedef struct {
   int32_t y;
 } Point;
 
+static const Point POINT_ORIGIN = {0, 0};
+static const Point POINT_INFINITY = {INT32_MAX, INT32_MAX};
+
 typedef struct {
   uint8_t r;
   uint8_t g;

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -1,0 +1,83 @@
+// Copyright © 2005-2007 Jens Gulden
+// Copyright © 2011-2023 Diego Elio Pettenò
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "imageprocess/primitives.h"
+#include "imageprocess/math_util.h"
+
+Rectangle rectangle_from_size(Point origin, RectangleSize size) {
+  return (Rectangle){
+      .vertex =
+          {
+              origin,
+              {
+                  .x = origin.x + size.width - 1,
+                  .y = origin.y + size.height - 1,
+              },
+          },
+  };
+}
+
+RectangleSize size_of_rectangle(Rectangle rect) {
+  return (RectangleSize){
+      .width = abs(rect.vertex[0].x - rect.vertex[1].x) + 1,
+      .height = abs(rect.vertex[0].y - rect.vertex[1].y) + 1,
+  };
+}
+
+Rectangle normalize_rectangle(Rectangle input) {
+  return (Rectangle){
+      .vertex =
+          {
+              {
+                  .x = min(input.vertex[0].x, input.vertex[1].x),
+                  .y = min(input.vertex[0].y, input.vertex[1].y),
+              },
+              {
+                  .x = max(input.vertex[0].x, input.vertex[1].x),
+                  .y = max(input.vertex[0].y, input.vertex[1].y),
+              },
+          },
+  };
+}
+
+Rectangle clip_rectangle(AVFrame *image, Rectangle area) {
+  Rectangle normal_area = normalize_rectangle(area);
+
+  return (Rectangle){
+      .vertex =
+          {
+              {
+                  .x = max(normal_area.vertex[0].x, 0),
+                  .y = max(normal_area.vertex[0].y, 0),
+              },
+              {
+                  .x = min(normal_area.vertex[1].x, (image->width - 1)),
+                  .y = min(normal_area.vertex[1].y, (image->height - 1)),
+              },
+          },
+  };
+}
+
+uint64_t count_pixels(Rectangle area) {
+  RectangleSize size = size_of_rectangle(area);
+
+  return size.width * size.height;
+}
+
+bool point_in_rectangle(Point p, Rectangle input_area) {
+  Rectangle area = normalize_rectangle(input_area);
+
+  return (p.x >= area.vertex[0].x && p.x <= area.vertex[1].x &&
+          p.y >= area.vertex[0].y && p.y <= area.vertex[1].y);
+}
+
+bool rectangles_overlap(Rectangle first_input, Rectangle second_input) {
+  Rectangle first = normalize_rectangle(first_input);
+  Rectangle second = normalize_rectangle(second_input);
+
+  return point_in_rectangle(first.vertex[0], second) ||
+         point_in_rectangle(first.vertex[1], second);
+}

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -1,0 +1,50 @@
+// Copyright © 2005-2007 Jens Gulden
+// Copyright © 2011-2023 Diego Elio Pettenò
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include <libavutil/frame.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+  int32_t x;
+  int32_t y;
+} Point;
+
+static const Point POINT_ORIGIN = {0, 0};
+static const Point POINT_INFINITY = {INT32_MAX, INT32_MAX};
+
+typedef struct {
+  uint8_t r;
+  uint8_t g;
+  uint8_t b;
+} Pixel;
+
+static const Pixel PIXEL_WHITE = {0xFF, 0xFF, 0xFF};
+
+typedef struct {
+  Point vertex[2];
+} Rectangle;
+
+static const Rectangle RECT_FULL_IMAGE = {{POINT_ORIGIN, POINT_INFINITY}};
+
+typedef struct {
+  uint32_t width;
+  uint32_t height;
+} RectangleSize;
+
+#define scan_rectangle(area)                                                   \
+  for (int32_t y = area.vertex[0].y; y <= area.vertex[1].y; y++)               \
+    for (int32_t x = area.vertex[0].x; x <= area.vertex[1].x; x++)
+
+Rectangle rectangle_from_size(Point origin, RectangleSize size);
+RectangleSize size_of_rectangle(Rectangle rect);
+Rectangle normalize_rectangle(Rectangle input);
+Rectangle clip_rectangle(AVFrame *image, Rectangle area);
+uint64_t count_pixels(Rectangle area);
+bool point_in_rectangle(Point p, Rectangle input_area);
+bool rectangles_overlap(Rectangle first_input, Rectangle second_input);

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,9 @@ test(
     'pytest suite',
     python,
     args: [
-        '-m', 'pytest', meson.project_source_root() + '/tests/unpaper_tests.py'
+        '-m', 'pytest',
+        '--basetemp=' + meson.current_build_dir() + '/test_output/',
+        meson.project_source_root() + '/tests/unpaper_tests.py'
     ],
     env: [
         'TEST_IMGSRC_DIR=' + meson.project_source_root() + '/tests/source_images/',

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,9 @@ configure_file(input: 'version.h.in', output: 'version.h', configuration: conf_d
 unpaper = executable(
     'unpaper',
     'file.c', 'imageprocess.c', 'parse.c', 'tools.c', 'unpaper.c',
-    'imageprocess/blit.c', 'imageprocess/pixel.c',
+    'imageprocess/blit.c',
+    'imageprocess/pixel.c',
+    'imageprocess/primitives.c',
     dependencies : unpaper_deps,
     install : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -32,7 +32,7 @@ configure_file(input: 'version.h.in', output: 'version.h', configuration: conf_d
 unpaper = executable(
     'unpaper',
     'file.c', 'imageprocess.c', 'parse.c', 'tools.c', 'unpaper.c',
-    'imageprocess/pixel.c',
+    'imageprocess/blit.c', 'imageprocess/pixel.c',
     dependencies : unpaper_deps,
     install : true,
 )

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,7 @@ configure_file(input: 'version.h.in', output: 'version.h', configuration: conf_d
 unpaper = executable(
     'unpaper',
     'file.c', 'imageprocess.c', 'parse.c', 'tools.c', 'unpaper.c',
+    'imageprocess/pixel.c',
     dependencies : unpaper_deps,
     install : true,
 )

--- a/parse.c
+++ b/parse.c
@@ -293,7 +293,7 @@ void parseMultiIndex(const char *optarg, struct MultiIndex *multiIndex) {
       }
 
       multiIndex->indexes[(multiIndex->count)++] = index;
-      if (c == '-') {   // range is specified: get range end
+      if (c == '-') { // range is specified: get range end
         if (components < 3) {
           errOutput("Invalid multi-index string \"%s\".", optarg);
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 Diego Elio Pettenò
+#
+# SPDX-License-Identifier: 0BSD
+
+meson >= 0.57
+ninja
+sphinx >= 3.4
+pytest
+pillow

--- a/tools.c
+++ b/tools.c
@@ -37,13 +37,8 @@ void initImage(AVFrame **image, int width, int height, int pixel_format,
   }
 
   if (fill) {
-    Pixel p = {
-        .r = (sheetBackground >> 16) & 0xff,
-        .g = (sheetBackground >> 8) & 0xff,
-        .b = sheetBackground & 0xff,
-    };
-
-    wipe_rectangle(*image, RECT_FULL_IMAGE, p, absBlackThreshold);
+    wipe_rectangle(*image, RECT_FULL_IMAGE, sheetBackgroundPixel,
+                   absBlackThreshold);
   }
 }
 
@@ -83,11 +78,9 @@ static bool clearPixel(int x, int y, AVFrame *image) {
 static void centerImageArea(int x, int y, int w, int h, AVFrame *source,
                             int toX, int toY, int ww, int hh, AVFrame *target) {
   if ((w < ww) || (h < hh)) { // white rest-border will remain, so clear first
-    wipe_rectangle(
-        target, (Rectangle){{{toX, toY}, {toX + ww - 1, toY + hh - 1}}},
-        (Pixel){(sheetBackground >> 16) & 0xff, (sheetBackground >> 8) & 0xff,
-                sheetBackground & 0xff},
-        absBlackThreshold);
+    wipe_rectangle(target,
+                   (Rectangle){{{toX, toY}, {toX + ww - 1, toY + hh - 1}}},
+                   sheetBackgroundPixel, absBlackThreshold);
   }
   if (w < ww) {
     toX += (ww - w) / 2;

--- a/tools.h
+++ b/tools.h
@@ -26,9 +26,6 @@ int getPixel(int x, int y, AVFrame *image);
 
 uint8_t getPixelDarknessInverse(int x, int y, AVFrame *image);
 
-int clearRect(const int left, const int top, const int right, const int bottom,
-              AVFrame *image, const int blackwhite);
-
 void copyImageArea(const int x, const int y, const int width, const int height,
                    AVFrame *source, const int toX, const int toY,
                    AVFrame *target);

--- a/tools.h
+++ b/tools.h
@@ -24,23 +24,8 @@ bool setPixel(int pixel, const int x, const int y, AVFrame *image);
 
 int getPixel(int x, int y, AVFrame *image);
 
-uint8_t getPixelDarknessInverse(int x, int y, AVFrame *image);
-
-void copyImageArea(const int x, const int y, const int width, const int height,
-                   AVFrame *source, const int toX, const int toY,
-                   AVFrame *target);
-
 void centerImage(AVFrame *source, int toX, int toY, int ww, int hh,
                  AVFrame *target);
-
-uint8_t inverseBrightnessRect(const int x1, const int y1, const int x2,
-                              const int y2, AVFrame *image);
-
-uint8_t inverseLightnessRect(const int x1, const int y1, const int x2,
-                             const int y2, AVFrame *image);
-
-uint8_t darknessRect(const int x1, const int y1, const int x2, const int y2,
-                     AVFrame *image);
 
 int countPixelsRect(int left, int top, int right, int bottom, int minColor,
                     int maxBrightness, bool clear, AVFrame *image);

--- a/unpaper.c
+++ b/unpaper.c
@@ -58,7 +58,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-int layout = LAYOUT_SINGLE;
+static int layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;

--- a/unpaper.c
+++ b/unpaper.c
@@ -26,8 +26,7 @@
 #include "version.h"
 
 #define WELCOME                                                                \
-  "unpaper " VERSION_STR                                                              \
-  "\n"                                                                         \
+  "unpaper " VERSION_STR "\n"                                                  \
   "License GPLv2: GNU GPL version 2.\n"                                        \
   "This is free software: you are free to change and redistribute it.\n"       \
   "There is NO WARRANTY, to the extent permitted by law.\n"

--- a/unpaper.c
+++ b/unpaper.c
@@ -976,6 +976,8 @@ int main(int argc, char *argv[]) {
     // -------------------------------------------------------------------
 
     bool inputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    bool outputWildcard = false;
+
     for (int i = 0; i < inputCount; i++) {
       bool ins = isInMultiIndex(inputNr, insertBlank);
       bool repl = isInMultiIndex(inputNr, replaceBlank);
@@ -1025,7 +1027,7 @@ int main(int argc, char *argv[]) {
                           // it over the array boundary
       errOutput("not enough output files given.");
     }
-    bool outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
+    outputWildcard = multisheets && (strchr(argv[optind], '%') != NULL);
     for (int i = 0; i < outputCount; i++) {
       if (outputWildcard) {
         sprintf(outputFilesBuffer[i], argv[optind], outputNr++);

--- a/unpaper.c
+++ b/unpaper.c
@@ -52,6 +52,7 @@ VERBOSE_LEVEL verbose = VERBOSE_NONE;
 
 INTERP_FUNCTIONS interpolateType = INTERP_CUBIC;
 
+Pixel sheetBackgroundPixel;
 unsigned int absBlackThreshold;
 unsigned int absWhiteThreshold;
 unsigned int absBlackfilterScanThreshold;
@@ -959,6 +960,9 @@ int main(int argc, char *argv[]) {
     endSheet = startSheet;
 
   // Calculate the constant absolute values based on the relative parameters.
+  sheetBackgroundPixel =
+      (Pixel){(sheetBackground >> 16) & 0xff, (sheetBackground >> 8) & 0xff,
+              sheetBackground & 0xff};
   absBlackThreshold = WHITE * (1.0 - blackThreshold);
   absWhiteThreshold = WHITE * (whiteThreshold);
   absBlackfilterScanThreshold = WHITE * (blackfilterScanThreshold);

--- a/unpaper.c
+++ b/unpaper.c
@@ -6,6 +6,7 @@
 
 /* --- The main program  -------------------------------------------------- */
 
+#include <assert.h>
 #include <getopt.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -58,7 +59,7 @@ float deskewScanRangeRad;
 float deskewScanStepRad;
 float deskewScanDeviationRad;
 
-static int layout = LAYOUT_SINGLE;
+static LAYOUTS layout = LAYOUT_SINGLE;
 int startSheet = 1;
 int endSheet = -1;
 int startInput = -1;
@@ -1188,12 +1189,17 @@ int main(int argc, char *argv[]) {
 
       if (verbose >= VERBOSE_MORE) {
         switch (layout) {
+        case LAYOUT_NONE:
+          printf("layout: none\n");
+          break;
         case LAYOUT_SINGLE:
           printf("layout: single\n");
           break;
         case LAYOUT_DOUBLE:
           printf("layout: double\n");
           break;
+        default:
+          assert(false); // unreachable
         }
 
         if (preRotate != 0) {

--- a/unpaper.h
+++ b/unpaper.h
@@ -35,7 +35,6 @@ extern float deskewScanRangeRad;
 extern float deskewScanStepRad;
 extern float deskewScanDeviationRad;
 
-extern int layout;
 extern int startSheet;
 extern int endSheet;
 extern int startInput;

--- a/unpaper.h
+++ b/unpaper.h
@@ -14,6 +14,7 @@
 #include <libavutil/frame.h>
 
 #include "constants.h"
+#include "imageprocess/pixel.h"
 
 /* --- preprocessor macros ------------------------------------------------ */
 
@@ -27,6 +28,7 @@ __attribute__((noreturn));
 extern VERBOSE_LEVEL verbose;
 extern INTERP_FUNCTIONS interpolateType;
 
+extern Pixel sheetBackgroundPixel;
 extern unsigned int absBlackThreshold;
 extern unsigned int absWhiteThreshold;
 extern unsigned int absBlackfilterScanThreshold;

--- a/unpaper.h
+++ b/unpaper.h
@@ -14,6 +14,7 @@
 #include <libavutil/frame.h>
 
 #include "constants.h"
+#include "imageprocess/math_util.h"
 #include "imageprocess/pixel.h"
 
 /* --- preprocessor macros ------------------------------------------------ */
@@ -156,29 +157,6 @@ static inline void limit(int *i, int max) {
     *i = max;
   }
 }
-
-#define max(a, b)                                                              \
-  ({                                                                           \
-    __typeof__(a) _a = (a);                                                    \
-    __typeof__(b) _b = (b);                                                    \
-    _a > _b ? _a : _b;                                                         \
-  })
-
-#define max3(a, b, c)                                                          \
-  ({                                                                           \
-    __typeof__(a) _a = (a);                                                    \
-    __typeof__(b) _b = (b);                                                    \
-    __typeof__(c) _c = (c);                                                    \
-    (_a > _b ? (_a > _c ? _a : _c) : (_b > _c ? _b : _c));                     \
-  })
-
-#define min3(a, b, c)                                                          \
-  ({                                                                           \
-    __typeof__(a) _a = (a);                                                    \
-    __typeof__(b) _b = (b);                                                    \
-    __typeof__(c) _c = (c);                                                    \
-    (_a < _b ? (_a < _c ? _a : _c) : (_b < _c ? _b : _c));                     \
-  })
 
 #define red(pixel) ((pixel >> 16) & 0xff)
 #define green(pixel) ((pixel >> 8) & 0xff)


### PR DESCRIPTION
Separate primitive types and functions as well as math utilities.


This reduces the duplication, and allows separating concepts a little
more cleanly.
