### PR TITLE
Enable -Werror in the CI builds.

### DIFF
--- a/.github/workflows/meson-build-and-test.yml
+++ b/.github/workflows/meson-build-and-test.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         compiler: [gcc, clang]
         meson_setup_flags:
-          - ""
-          - "--buildtype=debugoptimized"
-          - "--buildtype=debugoptimized -Db_lto=true"
+          - "-Dwerror=true"
+          - "--buildtype=debugoptimized -Dwerror=true"
+          - "--buildtype=debugoptimized -Dwerror=true -Db_lto=true"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Enable -Werror in the CI builds.

While I do not like enabling `-Werror` for final users builds, there
is no reason why the CI builds shouldn't use it to ensure a
zero-warning clean build.

See https://flameeyes.blog/2009/02/25/future-proof-your-code-dont-use-werror/ for my rationale.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/148).
* __->__ #148
* #147
* #146