### PR TITLE
Introduce some build support scripts.

### DIFF
--- a/build-scripts/build-all.sh
+++ b/build-scripts/build-all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: MIT
+
+if git status &>/dev/null; then
+  ROOT=$(git rev-parse --show-toplevel)
+elif sl root &>/dev/null; then
+  ROOT=$(sl root)
+else
+  echo "Unable to detect SCM." >&2
+  exit 1
+fi
+
+cd "$ROOT"
+for file in meson-environments/*.ini; do
+  environment=$(basename "${file}" .ini)
+
+  meson compile -C "builddir/${environment}" || exit $?
+done

--- a/build-scripts/setup-all.sh
+++ b/build-scripts/setup-all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: MIT
+
+if git status &>/dev/null; then
+  ROOT=$(git rev-parse --show-toplevel)
+elif sl root &>/dev/null; then
+  ROOT=$(sl root)
+else
+  echo "Unable to detect SCM." >&2
+  exit 1
+fi
+
+cd "$ROOT"
+for file in meson-environments/*.ini; do
+  environment=$(basename "${file}" .ini)
+
+  meson setup --reconfigure --native-file "${file}" "builddir/${environment}" || exit $?
+done

--- a/build-scripts/test-all.sh
+++ b/build-scripts/test-all.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: MIT
+
+if git status &>/dev/null; then
+  ROOT=$(git rev-parse --show-toplevel)
+elif sl root &>/dev/null; then
+  ROOT=$(sl root)
+else
+  echo "Unable to detect SCM." >&2
+  exit 1
+fi
+
+cd "$ROOT"
+for file in meson-environments/*.ini; do
+  environment=$(basename "${file}" .ini)
+
+  meson test -C "builddir/${environment}" || exit $?
+done

--- a/meson-environments/clang-o2.ini
+++ b/meson-environments/clang-o2.ini
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: 0BSD
+
+[binaries]
+c = 'clang'
+c_ld = 'lld'
+
+[built-in options]
+buildtype = 'debugoptimized'
+werror = true
+b_lto = true

--- a/meson-environments/gcc-o0.ini
+++ b/meson-environments/gcc-o0.ini
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: 0BSD
+
+[binaries]
+c = 'gcc'
+c_ld = 'bfd'
+
+[built-in options]
+werror = true

--- a/meson-environments/gcc-o2.ini
+++ b/meson-environments/gcc-o2.ini
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024 The unpaper authors
+#
+# SPDX-License-Identifier: 0BSD
+
+[binaries]
+c = 'gcc'
+c_ld = 'gold'
+
+[built-in options]
+buildtype = 'debugoptimized'
+werror = true
+b_lto = true


### PR DESCRIPTION
Introduce some build support scripts.

This includes native machine files for GCC and CLANG builds, plus
some scripts to build and test them all.
