### PR TITLE
grayfilter: make scan_size an actual RectangleSize struct.

### DIFF
--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -13,10 +13,7 @@ uint64_t noisefilter(AVFrame *image, uint64_t intensity,
                      uint8_t min_white_level, uint8_t abs_black_threshold);
 
 typedef struct {
-  struct {
-    uint32_t horizontal;
-    uint32_t vertical;
-  } scan_size;
+  RectangleSize scan_size;
 
   struct {
     uint32_t horizontal;


### PR DESCRIPTION
grayfilter: make scan_size an actual RectangleSize struct.

This simplfiies the logic a bit: instead of moving all four coordinates, move
the origin point, and use the defined size.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/155).
* #156
* __->__ #155