### PR TITLE
Create new primitives to shift points and rectangles.

### DIFF
--- a/imageprocess.c
+++ b/imageprocess.c
@@ -436,14 +436,14 @@ void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],
   AVFrame *newimage;
   const Rectangle area = maskToRectangle(mask);
   const RectangleSize size = size_of_rectangle(area);
+  const Rectangle full_image = clip_rectangle(image, RECT_FULL_IMAGE);
 
   const Point target = {center[X] - size.width / 2,
                         center[Y] - size.height / 2};
 
   Rectangle new_area = rectangle_from_size(target, size);
-  Rectangle clipped_area = clip_rectangle(image, new_area);
 
-  if (memcmp(&new_area, &clipped_area, sizeof(new_area)) == 0) {
+  if (rectangle_in_rectangle(new_area, full_image)) {
     verboseLog(VERBOSE_NORMAL, "centering mask [%d,%d,%d,%d] (%d,%d): %d, %d\n",
                area.vertex[0].x, area.vertex[0].y, area.vertex[1].x,
                area.vertex[1].y, center[X], center[Y],

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -7,6 +7,20 @@
 #include "imageprocess/primitives.h"
 #include "imageprocess/math_util.h"
 
+Delta distance_between(Point a, Point b) {
+  return (Delta){
+      b.x - a.x,
+      b.y - a.y,
+  };
+}
+
+Point shift_point(Point p, Delta d) {
+  return (Point){
+      p.x + d.horizontal,
+      p.y + d.vertical,
+  };
+}
+
 Rectangle rectangle_from_size(Point origin, RectangleSize size) {
   return (Rectangle){
       .vertex =
@@ -61,6 +75,13 @@ Rectangle clip_rectangle(AVFrame *image, Rectangle area) {
   };
 }
 
+Rectangle shift_rectangle(Rectangle rect, Delta d) {
+  return (Rectangle){{
+      shift_point(rect.vertex[0], d),
+      shift_point(rect.vertex[1], d),
+  }};
+}
+
 uint64_t count_pixels(Rectangle area) {
   RectangleSize size = size_of_rectangle(area);
 
@@ -72,6 +93,11 @@ bool point_in_rectangle(Point p, Rectangle input_area) {
 
   return (p.x >= area.vertex[0].x && p.x <= area.vertex[1].x &&
           p.y >= area.vertex[0].y && p.y <= area.vertex[1].y);
+}
+
+bool rectangle_in_rectangle(Rectangle inner, Rectangle outer) {
+  return point_in_rectangle(inner.vertex[0], outer) &&
+         point_in_rectangle(inner.vertex[1], outer);
 }
 
 bool rectangles_overlap(Rectangle first_input, Rectangle second_input) {

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -21,6 +21,23 @@ typedef struct {
   (Point) { INT32_MAX, INT32_MAX }
 
 typedef struct {
+  int32_t horizontal;
+  int32_t vertical;
+} Delta;
+
+Delta distance_between(Point a, Point b);
+Point shift_point(Point p, Delta d);
+
+#define DELTA_UPWARD                                                           \
+  (Delta) { 0, -1 }
+#define DELTA_DOWNWARD                                                         \
+  (Delta) { 0, 1 }
+#define DELTA_LEFTWARD                                                         \
+  (Delta) { -1, 0 }
+#define DELTA_RIGHTWARD                                                        \
+  (Delta) { 1, 0 }
+
+typedef struct {
   uint8_t r;
   uint8_t g;
   uint8_t b;
@@ -51,8 +68,12 @@ Rectangle rectangle_from_size(Point origin, RectangleSize size);
 RectangleSize size_of_rectangle(Rectangle rect);
 Rectangle normalize_rectangle(Rectangle input);
 Rectangle clip_rectangle(AVFrame *image, Rectangle area);
+Rectangle shift_rectangle(Rectangle rect, Delta d);
+
 uint64_t count_pixels(Rectangle area);
+
 bool point_in_rectangle(Point p, Rectangle input_area);
+bool rectangle_in_rectangle(Rectangle inner, Rectangle outer);
 bool rectangles_overlap(Rectangle first_input, Rectangle second_input);
 bool rectangle_overlap_any(Rectangle first_input, size_t count,
                            Rectangle *rectangles);


### PR DESCRIPTION
Create new primitives to shift points and rectangles.

A lot of the code up to now have to move x/y coordinates over
a certain pattern. Providing some primitive functions for abstractions
make it possible to pay more attention to what is done, rather
than which variable is used.

Also include a boundary check for a rectangle-in-rectangle which
is another common operation.

This also fixes the blackfilter scan to check for the *correct* vertex.
