### PR TITLE
Move the image shifting to the blit unit.

### DIFF
--- a/imageprocess.c
+++ b/imageprocess.c
@@ -112,24 +112,6 @@ void resize(int w, int h, AVFrame **image) {
   replaceImage(image, &resized);
 }
 
-/**
- * Shifts the image.
- *
- * @param shiftX horizontal shifting
- * @param shiftY vertical shifting
- */
-void shift(int shiftX, int shiftY, AVFrame **image) {
-  AVFrame *newimage;
-
-  // allocate new buffer's memory
-  initImage(&newimage, (*image)->width, (*image)->height, (*image)->format,
-            true);
-
-  copy_rectangle(*image, newimage, RECT_FULL_IMAGE, POINT_ORIGIN,
-                 absBlackThreshold);
-  replaceImage(image, &newimage);
-}
-
 /* --- mask-detection ----------------------------------------------------- */
 
 /**

--- a/imageprocess.c
+++ b/imageprocess.c
@@ -363,68 +363,6 @@ void applyWipes(const Mask *area, int areaCount, AVFrame *image) {
   }
 }
 
-/* --- mirroring ---------------------------------------------------------- */
-
-/**
- * Mirrors an image either horizontally, vertically, or both.
- */
-void mirror(int directions, AVFrame *image) {
-  const bool horizontal = !!((directions & 1 << HORIZONTAL) != 0);
-  const bool vertical = !!((directions & 1 << VERTICAL) != 0);
-  int untilX = ((horizontal == true) && (vertical == false))
-                   ? ((image->width - 1) >> 1)
-                   : (image->width - 1); // w>>1 == (int)(w-0.5)/2
-  int untilY =
-      (vertical == true) ? ((image->height - 1) >> 1) : image->height - 1;
-
-  for (int y = 0; y <= untilY; y++) {
-    const int yy = (vertical == true) ? (image->height - y - 1) : y;
-    if ((vertical == true) && (horizontal == true) &&
-        (y ==
-         yy)) { // last middle line in odd-lined image mirrored both h and v
-      untilX = ((image->width - 1) >> 1);
-    }
-    for (int x = 0; x <= untilX; x++) {
-      const int xx = (horizontal == true) ? (image->width - x - 1) : x;
-      Point point1 = {x, y};
-      Point point2 = {xx, yy};
-      Pixel pixel1 = get_pixel(image, point1);
-      Pixel pixel2 = get_pixel(image, point2);
-      set_pixel(image, point1, pixel2, absBlackThreshold);
-      set_pixel(image, point2, pixel1, absBlackThreshold);
-    }
-  }
-}
-
-/* --- flip-rotating ------------------------------------------------------ */
-
-/**
- * Rotates an image clockwise or anti-clockwise in 90-degrees.
- *
- * @param direction either -1 (rotate anti-clockwise) or 1 (rotate clockwise)
- */
-void flipRotate(int direction, AVFrame **image) {
-  AVFrame *newimage;
-
-  // exchanged width and height
-  initImage(&newimage, (*image)->height, (*image)->width, (*image)->format,
-            false);
-
-  for (int y = 0; y < (*image)->height; y++) {
-    const int xx = ((direction > 0) ? (*image)->height - 1 : 0) - y * direction;
-    for (int x = 0; x < (*image)->width; x++) {
-      const int yy =
-          ((direction < 0) ? (*image)->width - 1 : 0) + x * direction;
-
-      Point point1 = {x, y};
-      Point point2 = {xx, yy};
-
-      set_pixel(newimage, point2, get_pixel(*image, point1), absBlackThreshold);
-    }
-  }
-  replaceImage(image, &newimage);
-}
-
 /* --- border-detection --------------------------------------------------- */
 
 /**

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -20,8 +20,6 @@ void stretch(int w, int h, AVFrame **image);
 
 void resize(int w, int h, AVFrame **image);
 
-void shift(int shiftX, int shiftY, AVFrame **image);
-
 /* --- mask-detection ----------------------------------------------------- */
 
 void detectMasks(AVFrame *image);

--- a/imageprocess.h
+++ b/imageprocess.h
@@ -32,14 +32,6 @@ void applyMasks(const Mask *masks, const int maskCount, AVFrame *image);
 
 void applyWipes(const Mask *area, int areaCount, AVFrame *image);
 
-/* --- mirroring ---------------------------------------------------------- */
-
-void mirror(int directions, AVFrame *image);
-
-/* --- flip-rotating ------------------------------------------------------ */
-
-void flipRotate(int direction, AVFrame **image);
-
 /* --- border-detection --------------------------------------------------- */
 
 void centerMask(AVFrame *image, const int center[COORDINATES_COUNT],

--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -171,3 +171,15 @@ void mirror(AVFrame *image, bool horizontal, bool vertical,
     }
   }
 }
+
+void shift_image(AVFrame **pImage, Delta d, uint8_t abs_black_threshold) {
+  AVFrame *newimage;
+
+  // allocate new buffer's memory
+  initImage(&newimage, (*pImage)->width, (*pImage)->height, (*pImage)->format,
+            true);
+
+  copy_rectangle(*pImage, newimage, RECT_FULL_IMAGE,
+                 shift_point(POINT_ORIGIN, d), abs_black_threshold);
+  replaceImage(pImage, &newimage);
+}

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -32,3 +32,6 @@ void flip_rotate_90(AVFrame **pImage, RotationDirection direction,
 // Mirrors an image either horizontally, vertically, or both.
 void mirror(AVFrame *image, bool horizontal, bool vertical,
             uint8_t abs_black_threshold);
+
+// Shifts the image.
+void shift_image(AVFrame **pImage, Delta d, uint8_t abs_black_threshold);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -20,3 +20,15 @@ uint64_t count_pixels_within_brightness(AVFrame *image, Rectangle area,
                                         uint8_t min_brightness,
                                         uint8_t max_brightness, bool clear,
                                         uint8_t abs_black_threshold);
+
+typedef int8_t RotationDirection;
+static const RotationDirection ROTATE_CLOCKWISE = 1;
+static const RotationDirection ROTATE_ANTICLOCKWISE = -1;
+
+// Rotates an image clockwise or anti-clockwise in 90-degrees.
+void flip_rotate_90(AVFrame **pImage, RotationDirection direction,
+                    uint8_t abs_black_threshold);
+
+// Mirrors an image either horizontally, vertically, or both.
+void mirror(AVFrame *image, bool horizontal, bool vertical,
+            uint8_t abs_black_threshold);

--- a/unpaper.c
+++ b/unpaper.c
@@ -1176,7 +1176,7 @@ int main(int argc, char *argv[]) {
           if (preRotate != 0) {
             verboseLog(VERBOSE_NORMAL, "pre-rotating %d degrees.\n", preRotate);
 
-            flipRotate(preRotate / 90, &page);
+            flip_rotate_90(&page, preRotate / 90, absBlackThreshold);
           }
 
           // if sheet-size is not known yet (and not forced by --sheet-size),
@@ -1243,7 +1243,8 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "pre-mirroring %s\n",
                    getDirections(preMirror));
 
-        mirror(preMirror, sheet);
+        mirror(sheet, !!(preMirror & (1 << HORIZONTAL)),
+               !!(preMirror & (1 << VERTICAL)), absBlackThreshold);
       }
 
       // pre-shifting
@@ -1900,7 +1901,8 @@ int main(int argc, char *argv[]) {
       if (postMirror != 0) {
         verboseLog(VERBOSE_NORMAL, "post-mirroring %s\n",
                    getDirections(postMirror));
-        mirror(postMirror, sheet);
+        mirror(sheet, !!(postMirror & (1 << HORIZONTAL)),
+               !!(postMirror & (1 << VERTICAL)), absBlackThreshold);
       }
 
       // post-shifting
@@ -1913,7 +1915,7 @@ int main(int argc, char *argv[]) {
       // post-rotating
       if (postRotate != 0) {
         verboseLog(VERBOSE_NORMAL, "post-rotating %d degrees.\n", postRotate);
-        flipRotate(postRotate / 90, &sheet);
+        flip_rotate_90(&sheet, postRotate / 90, absBlackThreshold);
       }
 
       // post-stretch

--- a/unpaper.c
+++ b/unpaper.c
@@ -1252,7 +1252,8 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "pre-shifting [%d,%d]\n", preShift[WIDTH],
                    preShift[HEIGHT]);
 
-        shift(preShift[WIDTH], preShift[HEIGHT], &sheet);
+        shift_image(&sheet, (Delta){preShift[WIDTH], preShift[HEIGHT]},
+                    absBlackThreshold);
       }
 
       // pre-masking
@@ -1909,7 +1910,9 @@ int main(int argc, char *argv[]) {
       if ((postShift[WIDTH] != 0) || ((postShift[HEIGHT] != 0))) {
         verboseLog(VERBOSE_NORMAL, "post-shifting [%d,%d]\n", postShift[WIDTH],
                    postShift[HEIGHT]);
-        shift(postShift[WIDTH], postShift[HEIGHT], &sheet);
+
+        shift_image(&sheet, (Delta){postShift[WIDTH], postShift[HEIGHT]},
+                    absBlackThreshold);
       }
 
       // post-rotating


### PR DESCRIPTION
Move the image shifting to the blit unit.

This also *fixes* the shifting, which we don't have good tests for (#160.)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/162).
* __->__ #162
* #161