### PR TITLE
Calculate blackfilter exclusions as Rectangles to begin with.

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "lib/options.h"
@@ -42,4 +44,16 @@ void options_init(Options *o) {
   o->no_border_multi_index = multi_index_empty();
   o->no_border_scan_multi_index = multi_index_empty();
   o->no_border_align_multi_index = multi_index_empty();
+}
+
+bool parse_rectangle(const char *str, Rectangle *rect) {
+  return sscanf(str, "%" SCNd32 ",%" SCNd32 ",%" SCNd32 ",%" SCNd32 "",
+                &rect->vertex[0].x, &rect->vertex[0].y, &rect->vertex[1].x,
+                &rect->vertex[1].y) == 4;
+}
+
+int print_rectangle(Rectangle rect) {
+  return printf("[%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 "]",
+                rect.vertex[0].x, rect.vertex[0].y, rect.vertex[1].x,
+                rect.vertex[1].y);
 }

--- a/lib/options.h
+++ b/lib/options.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 #include "constants.h"
+#include "imageprocess/primitives.h"
 #include "parse.h"
 
 typedef struct {
@@ -37,3 +40,6 @@ typedef struct {
 } Options;
 
 void options_init(Options *o);
+
+bool parse_rectangle(const char *str, Rectangle *rect);
+int print_rectangle(Rectangle rect);

--- a/unpaper.h
+++ b/unpaper.h
@@ -53,23 +53,6 @@ static inline int pixelValue(uint8_t r, uint8_t g, uint8_t b) {
   return (r) << 16 | (g) << 8 | (b);
 }
 
-/* Conversion functions from old types to new types */
-static inline Rectangle maskToRectangle(const Mask mask) {
-  return (Rectangle){
-      .vertex =
-          {
-              {
-                  .x = mask[LEFT],
-                  .y = mask[TOP],
-              },
-              {
-                  .x = mask[RIGHT],
-                  .y = mask[BOTTOM],
-              },
-          },
-  };
-}
-
 static inline Pixel pixelValueToPixel(uint32_t pixelValue) {
   return (Pixel){
       .r = (pixelValue >> 16) & 0xff,


### PR DESCRIPTION
Calculate blackfilter exclusions as Rectangles to begin with.

This removes the remaining maskToRectangle() usage, so that this
convenience function can go away.

The logic in place for auto-selecting the exclusion zone is actually different,
in so far as it provides a more correct selection based on size, rather
than being off-by-one due to the lack of `-1` in the calculation.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/176).
* #178
* #177
* __->__ #176