### PR TITLE
Replace parsing and printing of colors with new generic functions.

### DIFF
--- a/file.c
+++ b/file.c
@@ -108,8 +108,8 @@ void loadImage(const char *filename, AVFrame **image, Pixel sheet_background,
     const uint32_t *palette = (const uint32_t *)frame->data[1];
     scan_rectangle(area) {
       const uint8_t palette_index = frame->data[0][frame->linesize[0] * y + x];
-      set_pixel(*image, (Point){x, y},
-                pixelValueToPixel(palette[palette_index]), abs_black_threshold);
+      set_pixel(*image, (Point){x, y}, pixel_from_value(palette[palette_index]),
+                abs_black_threshold);
     }
   } break;
 

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -67,6 +67,21 @@ static Pixel get_pixel_components(AVFrame *image, Point coords,
   return pixel;
 }
 
+Pixel pixel_from_value(uint32_t value) {
+  return (Pixel){
+      .r = (value >> 16) & 0xff,
+      .g = (value >> 8) & 0xff,
+      .b = value & 0xff,
+  };
+}
+
+int compare_pixel(Pixel a, Pixel b) {
+  if (memcmp(&a, &b, sizeof(Pixel)) == 0) {
+    return 0;
+  }
+  return pixel_grayscale(a) < pixel_grayscale(b) ? -1 : 1;
+}
+
 /* Returns the color or grayscale value of a single pixel.
  * Always returns a color-compatible value (which may be interpreted as 8-bit
  * grayscale)

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -11,6 +11,8 @@
 
 #include "imageprocess/primitives.h"
 
+Pixel pixel_from_value(uint32_t value);
+int compare_pixel(Pixel a, Pixel b);
 Pixel get_pixel(AVFrame *image, Point coords);
 uint8_t get_pixel_grayscale(AVFrame *image, Point coords);
 uint8_t get_pixel_lightness(AVFrame *image, Point coords);

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -44,7 +44,9 @@ typedef struct {
 } Pixel;
 
 #define PIXEL_WHITE                                                            \
-  (Pixel) { 0xFF, 0xFF, 0xFF }
+  (Pixel) { UINT8_MAX, UINT8_MAX, UINT8_MAX }
+#define PIXEL_BLACK                                                            \
+  (Pixel) { 0, 0, 0 }
 
 typedef struct {
   Point vertex[2];

--- a/lib/options.c
+++ b/lib/options.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "imageprocess/pixel.h"
 #include "lib/options.h"
 
 static struct MultiIndex multi_index_empty(void) {
@@ -56,4 +57,34 @@ int print_rectangle(Rectangle rect) {
   return printf("[%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 "] ",
                 rect.vertex[0].x, rect.vertex[0].y, rect.vertex[1].x,
                 rect.vertex[1].y);
+}
+
+bool parse_color(const char *str, Pixel *color) {
+  if (strcmp(str, "black") == 0) {
+    *color = PIXEL_BLACK;
+    return true;
+  }
+  if (strcmp(str, "white") == 0) {
+    *color = PIXEL_WHITE;
+    return true;
+  }
+
+  uint32_t colorValue;
+  if (sscanf(str, "%" SCNd32, &colorValue) != 1) {
+    return false;
+  }
+
+  *color = pixel_from_value(colorValue);
+  return true;
+}
+
+int print_color(Pixel color) {
+  if (compare_pixel(color, PIXEL_BLACK) == 0) {
+    return printf("black");
+  }
+  if (compare_pixel(color, PIXEL_WHITE) == 0) {
+    return printf("white");
+  }
+
+  return printf("#%02x%02x%02x", color.r, color.g, color.b);
 }

--- a/lib/options.h
+++ b/lib/options.h
@@ -43,3 +43,6 @@ void options_init(Options *o);
 
 bool parse_rectangle(const char *str, Rectangle *rect);
 int print_rectangle(Rectangle rect);
+
+bool parse_color(const char *str, Pixel *color);
+int print_color(Pixel color);

--- a/parse.c
+++ b/parse.c
@@ -210,18 +210,6 @@ void parseSize(char *s, int i[2], int dpi) {
 }
 
 /**
- * Parses a color. Currently only "black" and "white".
- */
-int parseColor(char *s) {
-  if (strcmp(s, "black") == 0)
-    return BLACK24;
-  if (strcmp(s, "white") == 0)
-    return WHITE24;
-
-  errOutput("cannot parse color '%s'.", s);
-}
-
-/**
  * Parses either a single float string, of a pair of two floats separated
  * by a comma.
  */

--- a/parse.h
+++ b/parse.h
@@ -22,8 +22,6 @@ void parseInts(char *s, int i[2]);
 
 void parseSize(char *s, int i[2], int dpi);
 
-int parseColor(char *s);
-
 void parseFloats(char *s, float f[2]);
 
 char *implode(char *buf, const char *s[], int cnt);

--- a/unpaper.c
+++ b/unpaper.c
@@ -176,14 +176,13 @@ int main(int argc, char *argv[]) {
   BorderScanParameters borderScanParams;
   int borderAlign = 0;                              // center
   int borderAlignMargin[DIRECTIONS_COUNT] = {0, 0}; // center
-  Pixel maskColorPixel;
+  Pixel maskColorPixel = PIXEL_WHITE;
   size_t pointCount = 0;
   Point points[MAX_POINTS];
   size_t maskCount = 0;
   Rectangle masks[MAX_MASKS];
   size_t preMaskCount = 0;
   Rectangle preMasks[MAX_MASKS];
-  int maskColor = WHITE24;
   size_t wipeCount = 0;
   Rectangle wipe[MAX_MASKS];
   int middleWipe[2] = {0, 0};
@@ -214,12 +213,11 @@ int main(int argc, char *argv[]) {
 
   Interpolation interpolateType = INTERP_CUBIC;
 
-  Pixel sheetBackgroundPixel;
+  Pixel sheetBackgroundPixel = PIXEL_WHITE;
   unsigned int absBlackThreshold;
   unsigned int absWhiteThreshold;
 
   int sheetSize[DIMENSIONS_COUNT] = {-1, -1};
-  int sheetBackground = WHITE24;
   int preRotate = 0;
   int postRotate = 0;
   int preMirror = 0;
@@ -475,7 +473,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_SHEET_BACKGROUND:
-      sheetBackground = parseColor(optarg);
+      if (!parse_color(optarg, &sheetBackgroundPixel)) {
+        errOutput("invalid value for sheet-background: %s", optarg);
+      }
       break;
 
     case 'x':
@@ -761,7 +761,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_MASK_COLOR:
-      sscanf(optarg, "%d", &maskColor);
+      if (!parse_color(optarg, &maskColorPixel)) {
+        errOutput("invalid value for mask-color: %s", optarg);
+      }
       break;
 
     case OPT_NO_MASK_CENTER:
@@ -966,8 +968,6 @@ int main(int argc, char *argv[]) {
     options.end_sheet = options.start_sheet;
 
   // Calculate the constant absolute values based on the relative parameters.
-  sheetBackgroundPixel = pixelValueToPixel(sheetBackground);
-  maskColorPixel = pixelValueToPixel(maskColor);
   absBlackThreshold = WHITE * (1.0 - blackThreshold);
   absWhiteThreshold = WHITE * (whiteThreshold);
 
@@ -1368,7 +1368,9 @@ int main(int argc, char *argv[]) {
                  maskScanMinimum[1]);
           printf("mask-scan-maximum: [%d,%d]\n", maskScanMaximum[0],
                  maskScanMaximum[1]);
-          printf("mask-color: %d\n", maskColor);
+          printf("mask-color: ");
+          print_color(maskColorPixel);
+          printf("\n");
           if (options.no_mask_scan_multi_index.count > 0) {
             printf("mask-scan DISABLED for sheets: ");
             printMultiIndex(options.no_mask_scan_multi_index);
@@ -1459,9 +1461,9 @@ int main(int argc, char *argv[]) {
         //}
         printf("white-threshold: %f\n", whiteThreshold);
         printf("black-threshold: %f\n", blackThreshold);
-        printf("sheet-background: %s %6x\n",
-               ((sheetBackground == BLACK24) ? "black" : "white"),
-               sheetBackground);
+        printf("sheet-background: ");
+        print_color(sheetBackgroundPixel);
+        printf("\n");
         printf("dpi: %d\n", dpi);
         printf("input-files per sheet: %d\n", options.input_count);
         printf("output-files per sheet: %d\n", options.output_count);

--- a/unpaper.h
+++ b/unpaper.h
@@ -42,19 +42,3 @@ static inline void limit(int *i, int max) {
     *i = max;
   }
 }
-
-#define red(pixel) ((pixel >> 16) & 0xff)
-#define green(pixel) ((pixel >> 8) & 0xff)
-#define blue(pixel) (pixel & 0xff)
-
-static inline int pixelValue(uint8_t r, uint8_t g, uint8_t b) {
-  return (r) << 16 | (g) << 8 | (b);
-}
-
-static inline Pixel pixelValueToPixel(uint32_t pixelValue) {
-  return (Pixel){
-      .r = (pixelValue >> 16) & 0xff,
-      .g = (pixelValue >> 8) & 0xff,
-      .b = pixelValue & 0xff,
-  };
-}


### PR DESCRIPTION
Replace parsing and printing of colors with new generic functions.

This makes mask-color and sheet-background act the same, and
removes the need for various pixel conversion functions.
