### PR TITLE
Wrap around the creation of compatible temporary images.

### DIFF
--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -189,8 +189,7 @@ void stretch_and_replace(Image *pImage, RectangleSize size,
   if (compare_sizes(size_of_image(*pImage), size) == 0)
     return;
 
-  Image target = create_image(size, pImage->frame->format, false, PIXEL_WHITE,
-                              abs_black_threshold);
+  Image target = create_compatible_image(*pImage, size, false);
 
   stretch_frame(*pImage, target, interpolate_type, abs_black_threshold);
   replace_image(pImage, &target);
@@ -233,8 +232,7 @@ void resize_and_replace(Image *pImage, RectangleSize size,
     return;
   }
 
-  Image resized = create_image(size, pImage->frame->format, true,
-                               sheet_background, abs_black_threshold);
+  Image resized = create_compatible_image(*pImage, size, true);
   center_image(*pImage, resized, POINT_ORIGIN, size, sheet_background,
                abs_black_threshold);
   replace_image(pImage, &resized);
@@ -245,9 +243,10 @@ void flip_rotate_90(Image *pImage, RotationDirection direction,
   RectangleSize image_size = size_of_image(*pImage);
 
   // exchanged width and height
-  Image newimage = create_image(
+  Image newimage = create_compatible_image(
+      *pImage,
       (RectangleSize){.width = image_size.height, .height = image_size.width},
-      pImage->frame->format, false, PIXEL_WHITE, abs_black_threshold);
+      false);
 
   for (int y = 0; y < image_size.height; y++) {
     const int xx =
@@ -306,8 +305,8 @@ void mirror(Image image, bool horizontal, bool vertical,
 void shift_image(Image *pImage, Delta d, Pixel sheet_background,
                  uint8_t abs_black_threshold) {
   // allocate new buffer's memory
-  Image newimage = create_image(size_of_image(*pImage), pImage->frame->format,
-                                true, sheet_background, abs_black_threshold);
+  Image newimage =
+      create_compatible_image(*pImage, size_of_image(*pImage), true);
 
   copy_rectangle(*pImage, newimage, full_image(*pImage),
                  shift_point(POINT_ORIGIN, d), abs_black_threshold);

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 
+#include <libavutil/mathematics.h> // for M_PI
+
 #include "constants.h"
 #include "imageprocess/deskew.h"
 #include "imageprocess/interpolate.h"

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 
 #include "constants.h"

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -21,6 +21,7 @@ Image create_image(RectangleSize size, int pixel_format, bool fill,
                    Pixel sheet_background, uint8_t abs_black_threshold);
 void replace_image(Image *image, Image *new_image);
 void free_image(Image *image);
+Image create_compatible_image(Image source, RectangleSize size, bool fill);
 
 RectangleSize size_of_image(Image image);
 Rectangle full_image(Image image);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/masks.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "imageprocess/blit.h"
+#include "imageprocess/masks.h"
 #include "imageprocess/pixel.h"
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
@@ -231,8 +235,7 @@ void center_mask(Image image, const Point center, const Rectangle area,
                area.vertex[0].x, area.vertex[0].y, area.vertex[1].x,
                area.vertex[1].y, center.x, center.y,
                target.x - area.vertex[0].x, target.y - area.vertex[0].y);
-    Image newimage = create_image(size, image.frame->format, false, PIXEL_WHITE,
-                                  abs_black_threshold);
+    Image newimage = create_compatible_image(image, size, false);
     copy_rectangle(image, newimage, area, POINT_ORIGIN, abs_black_threshold);
     wipe_rectangle(image, area, sheet_background, abs_black_threshold);
     copy_rectangle(newimage, image, full_image(newimage), target,
@@ -302,8 +305,7 @@ void align_mask(Image image, const Rectangle inside_area,
              target.y, target.x - inside_area.vertex[0].x,
              target.y - inside_area.vertex[0].y);
 
-  Image newimage = create_image(inside_size, image.frame->format, true,
-                                sheet_background, abs_black_threshold);
+  Image newimage = create_compatible_image(image, inside_size, true);
   copy_rectangle(image, newimage, inside_area, POINT_ORIGIN,
                  abs_black_threshold);
   wipe_rectangle(image, inside_area, sheet_background, abs_black_threshold);

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -4,8 +4,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/primitives.h"
+#include <stdlib.h>
+
 #include "imageprocess/math_util.h"
+#include "imageprocess/primitives.h"
 
 Delta distance_between(Point a, Point b) {
   return (Delta){

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {

--- a/lib/options.c
+++ b/lib/options.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/unpaper.c
+++ b/unpaper.c
@@ -1755,12 +1755,10 @@ int main(int argc, char *argv[]) {
                      points[i].y, rotation);
 
           if (rotation != 0.0) {
-            Image rect =
-                create_image(size_of_rectangle(masks[i]), sheet.frame->format,
-                             false, sheetBackgroundPixel, absBlackThreshold);
-            Image rectTarget =
-                create_image(size_of_image(rect), sheet.frame->format, true,
-                             sheetBackgroundPixel, absBlackThreshold);
+            Image rect = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), false);
+            Image rectTarget = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), true);
 
             // copy area to rotate into rSource
             copy_rectangle(sheet, rect,
@@ -1949,11 +1947,11 @@ int main(int argc, char *argv[]) {
 
         for (int j = 0; j < options.output_count; j++) {
           // get pagebuffer
-          page = create_image(
+          page = create_compatible_image(
+              sheet,
               (RectangleSize){sheet.frame->width / options.output_count,
                               sheet.frame->height},
-              sheet.frame->format, false, sheetBackgroundPixel,
-              absBlackThreshold);
+              false);
           copy_rectangle(
               sheet, page,
               (Rectangle){{{page.frame->width * j, 0},


### PR DESCRIPTION
Wrap around the creation of compatible temporary images.

Instead of having to get the details of AVFrame every time, allow
the creation of a new image based on the format and parameters
of another.

This allows making AVFrame opaque to *most* of the code, except
for (obviously) the image manipulation routines.

The unfortunate side effect is needing to fix all the includes that
were previously imported via libavutil.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/182).
* #190
* #189
* #188
* #184
* #183
* __->__ #182