### PR TITLE
Remove the maskValid array.

### DIFF
--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -188,14 +188,14 @@ static const Rectangle INVALID_MASK = {{{-1, -1}, {-1, -1}}};
  */
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]) {
+                    Rectangle masks[]) {
   size_t masks_count = 0;
   if (!params.scan_horizontal && !params.scan_vertical) {
     return masks_count;
   }
 
   for (size_t i = 0; i < points_count; i++) {
-    mask_valid[i] = detect_mask(image, params, points[i], &masks[i]);
+    bool mask_valid = detect_mask(image, params, points[i], &masks[i]);
 
     // Compare the newly-detected mask with an invalid mask where all the
     // vertex are (-1, -1)
@@ -206,7 +206,7 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
           VERBOSE_NORMAL, "auto-masking (%d,%d): %d,%d,%d,%d%s\n", points[i].x,
           points[i].y, masks[i].vertex[0].x, masks[i].vertex[0].y,
           masks[i].vertex[1].x, masks[i].vertex[1].y,
-          mask_valid[i] ? "" : " (invalid detection, using full page size)");
+          mask_valid ? "" : " (invalid detection, using full page size)");
     } else {
       verboseLog(VERBOSE_NORMAL, "auto-masking (%d,%d): NO MASK FOUND\n",
                  points[i].x, points[i].y);

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -50,7 +50,7 @@ validate_mask_detection_parameters(int scan_directions,
 
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]);
+                    Rectangle masks[]);
 
 void center_mask(Image image, const Point center, const Rectangle area);
 

--- a/unpaper.c
+++ b/unpaper.c
@@ -234,7 +234,6 @@ int main(int argc, char *argv[]) {
   Border preBorder = {0, 0, 0, 0};
   Border postBorder = {0, 0, 0, 0};
   Border border = {0, 0, 0, 0};
-  bool maskValid[MAX_MASKS];
   float whiteThreshold = 0.9;
   float blackThreshold = 0.33;
   bool writeoutput = true;
@@ -579,7 +578,6 @@ int main(int argc, char *argv[]) {
     case 'm':
       if (maskCount < MAX_MASKS) {
         if (parse_rectangle(optarg, &masks[maskCount])) {
-          maskValid[maskCount] = true;
           maskCount++;
         }
       } else {
@@ -1675,8 +1673,7 @@ int main(int argc, char *argv[]) {
       // mask-detection
       if (!isExcluded(nr, options.no_mask_scan_multi_index,
                       options.ignore_multi_index)) {
-        detect_masks(sheet, maskDetectionParams, points, pointCount, maskValid,
-                     masks);
+        detect_masks(sheet, maskDetectionParams, points, pointCount, masks);
       } else {
         verboseLog(VERBOSE_MORE, "+ mask-scan DISABLED for sheet %d\n", nr);
       }
@@ -1712,7 +1709,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before deskewing disabled)\n");
         }
@@ -1764,7 +1761,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }


### PR DESCRIPTION
Remove the maskValid array.

This array is not actually consumed anywhere. Whether the mask is
valid or not is only relevant when logging it.

So make the boolean local to the function, and stop carrying these 800 bytes (minimum) on the stack.
