### PR TITLE
Make masks handling use dedicated structures.

### DIFF
--- a/file.c
+++ b/file.c
@@ -108,8 +108,8 @@ void loadImage(const char *filename, AVFrame **image, Pixel sheet_background,
     const uint32_t *palette = (const uint32_t *)frame->data[1];
     scan_rectangle(area) {
       const uint8_t palette_index = frame->data[0][frame->linesize[0] * y + x];
-      set_pixel(*image, (Point){x, y},
-                pixelValueToPixel(palette[palette_index]), abs_black_threshold);
+      set_pixel(*image, (Point){x, y}, pixel_from_value(palette[palette_index]),
+                abs_black_threshold);
     }
   } break;
 

--- a/file.c
+++ b/file.c
@@ -110,8 +110,8 @@ void loadImage(const char *filename, Image *image, Pixel sheet_background,
     const uint32_t *palette = (const uint32_t *)frame->data[1];
     scan_rectangle(area) {
       const uint8_t palette_index = frame->data[0][frame->linesize[0] * y + x];
-      set_pixel(*image, (Point){x, y}, pixel_from_value(palette[palette_index]),
-                abs_black_threshold);
+      set_pixel(*image, (Point){x, y},
+                pixel_from_value(palette[palette_index]));
     }
   } break;
 
@@ -131,8 +131,7 @@ void loadImage(const char *filename, Image *image, Pixel sheet_background,
  * @param type filetype of the image to save
  * @return true on success, false on failure
  */
-void saveImage(char *filename, Image input, int outputPixFmt,
-               Pixel sheet_background, uint8_t abs_black_threshold) {
+void saveImage(char *filename, Image input, int outputPixFmt) {
   enum AVCodecID output_codec = -1;
   const AVCodec *codec;
   AVFormatContext *out_ctx;
@@ -174,9 +173,8 @@ void saveImage(char *filename, Image input, int outputPixFmt,
 
   if (input.frame->format != outputPixFmt) {
     output = create_image(size_of_image(input), outputPixFmt, false,
-                          sheet_background, abs_black_threshold);
-    copy_rectangle(input, output, full_image(input), POINT_ORIGIN,
-                   abs_black_threshold);
+                          input.background, input.abs_black_threshold);
+    copy_rectangle(input, output, full_image(input), POINT_ORIGIN);
   }
 
   codec = avcodec_find_encoder(output_codec);
@@ -255,12 +253,10 @@ void saveImage(char *filename, Image input, int outputPixFmt,
 /**
  * Saves the image if full debugging mode is enabled.
  */
-void saveDebug(char *filenameTemplate, int index, Image image,
-               Pixel sheet_background, uint8_t abs_black_threshold) {
+void saveDebug(char *filenameTemplate, int index, Image image) {
   if (verbose >= VERBOSE_DEBUG_SAVE) {
     char debugFilename[100];
     sprintf(debugFilename, filenameTemplate, index);
-    saveImage(debugFilename, image, image.frame->format, sheet_background,
-              abs_black_threshold);
+    saveImage(debugFilename, image, image.frame->format);
   }
 }

--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -189,8 +189,7 @@ void stretch_and_replace(Image *pImage, RectangleSize size,
   if (compare_sizes(size_of_image(*pImage), size) == 0)
     return;
 
-  Image target = create_image(size, pImage->frame->format, false, PIXEL_WHITE,
-                              abs_black_threshold);
+  Image target = create_compatible_image(*pImage, size, false);
 
   stretch_frame(*pImage, target, interpolate_type, abs_black_threshold);
   replace_image(pImage, &target);
@@ -233,8 +232,7 @@ void resize_and_replace(Image *pImage, RectangleSize size,
     return;
   }
 
-  Image resized = create_image(size, pImage->frame->format, true,
-                               sheet_background, abs_black_threshold);
+  Image resized = create_compatible_image(*pImage, size, true);
   center_image(*pImage, resized, POINT_ORIGIN, size, sheet_background,
                abs_black_threshold);
   replace_image(pImage, &resized);
@@ -245,9 +243,10 @@ void flip_rotate_90(Image *pImage, RotationDirection direction,
   RectangleSize image_size = size_of_image(*pImage);
 
   // exchanged width and height
-  Image newimage = create_image(
+  Image newimage = create_compatible_image(
+      *pImage,
       (RectangleSize){.width = image_size.height, .height = image_size.width},
-      pImage->frame->format, false, PIXEL_WHITE, abs_black_threshold);
+      false);
 
   for (int y = 0; y < image_size.height; y++) {
     const int xx =
@@ -306,8 +305,8 @@ void mirror(Image image, bool horizontal, bool vertical,
 void shift_image(Image *pImage, Delta d, Pixel sheet_background,
                  uint8_t abs_black_threshold) {
   // allocate new buffer's memory
-  Image newimage = create_image(size_of_image(*pImage), pImage->frame->format,
-                                true, sheet_background, abs_black_threshold);
+  Image newimage =
+      create_compatible_image(*pImage, size_of_image(*pImage), true);
 
   copy_rectangle(*pImage, newimage, full_image(*pImage),
                  shift_point(POINT_ORIGIN, d), abs_black_threshold);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -4,20 +4,20 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdint.h>
 
+#include "imageprocess/image.h"
 #include "imageprocess/interpolate.h"
 #include "imageprocess/primitives.h"
 
-uint64_t wipe_rectangle(AVFrame *image, Rectangle input_area, Pixel color,
+uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color,
                         uint8_t abs_black_threshold);
-void copy_rectangle(AVFrame *source, AVFrame *target, Rectangle source_area,
+void copy_rectangle(Image source, Image target, Rectangle source_area,
                     Point target_coords, uint8_t abs_black_threshold);
-uint8_t inverse_brightness_rect(AVFrame *image, Rectangle input_area);
-uint8_t inverse_lightness_rect(AVFrame *image, Rectangle input_area);
-uint8_t darkness_rect(AVFrame *image, Rectangle input_area);
-uint64_t count_pixels_within_brightness(AVFrame *image, Rectangle area,
+uint8_t inverse_brightness_rect(Image image, Rectangle input_area);
+uint8_t inverse_lightness_rect(Image image, Rectangle input_area);
+uint8_t darkness_rect(Image image, Rectangle input_area);
+uint64_t count_pixels_within_brightness(Image image, Rectangle area,
                                         uint8_t min_brightness,
                                         uint8_t max_brightness, bool clear,
                                         uint8_t abs_black_threshold);
@@ -26,31 +26,26 @@ typedef int8_t RotationDirection;
 static const RotationDirection ROTATE_CLOCKWISE = 1;
 static const RotationDirection ROTATE_ANTICLOCKWISE = -1;
 
-AVFrame *create_image(RectangleSize size, int pixel_format, bool fill,
-                      Pixel sheet_background, uint8_t abs_black_threshold);
-void replace_image(AVFrame **image, AVFrame **new_image);
-void free_image(AVFrame **pImage);
-
-void center_image(AVFrame *source, AVFrame *target, Point target_origin,
+void center_image(Image source, Image target, Point target_origin,
                   RectangleSize target_size, Pixel sheet_background,
                   uint8_t abs_black_threshold);
 
-void stretch_and_replace(AVFrame **pImage, RectangleSize size,
+void stretch_and_replace(Image *pImage, RectangleSize size,
                          Interpolation interpolate_type,
                          uint8_t abs_black_threshold);
 
-void resize_and_replace(AVFrame **pImage, RectangleSize size,
+void resize_and_replace(Image *pImage, RectangleSize size,
                         Interpolation interpolate_type, Pixel sheet_background,
                         uint8_t abs_black_threshold);
 
 // Rotates an image clockwise or anti-clockwise in 90-degrees.
-void flip_rotate_90(AVFrame **pImage, RotationDirection direction,
+void flip_rotate_90(Image *pImage, RotationDirection direction,
                     uint8_t abs_black_threshold);
 
 // Mirrors an image either horizontally, vertically, or both.
-void mirror(AVFrame *image, bool horizontal, bool vertical,
+void mirror(Image image, bool horizontal, bool vertical,
             uint8_t abs_black_threshold);
 
 // Shifts the image.
-void shift_image(AVFrame **pImage, Delta d, Pixel sheet_background,
+void shift_image(Image *pImage, Delta d, Pixel sheet_background,
                  uint8_t abs_black_threshold);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -10,42 +10,34 @@
 #include "imageprocess/interpolate.h"
 #include "imageprocess/primitives.h"
 
-uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color,
-                        uint8_t abs_black_threshold);
+uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color);
 void copy_rectangle(Image source, Image target, Rectangle source_area,
-                    Point target_coords, uint8_t abs_black_threshold);
+                    Point target_coords);
 uint8_t inverse_brightness_rect(Image image, Rectangle input_area);
 uint8_t inverse_lightness_rect(Image image, Rectangle input_area);
 uint8_t darkness_rect(Image image, Rectangle input_area);
 uint64_t count_pixels_within_brightness(Image image, Rectangle area,
                                         uint8_t min_brightness,
-                                        uint8_t max_brightness, bool clear,
-                                        uint8_t abs_black_threshold);
+                                        uint8_t max_brightness, bool clear);
 
 typedef int8_t RotationDirection;
 static const RotationDirection ROTATE_CLOCKWISE = 1;
 static const RotationDirection ROTATE_ANTICLOCKWISE = -1;
 
 void center_image(Image source, Image target, Point target_origin,
-                  RectangleSize target_size, Pixel sheet_background,
-                  uint8_t abs_black_threshold);
+                  RectangleSize target_size);
 
 void stretch_and_replace(Image *pImage, RectangleSize size,
-                         Interpolation interpolate_type,
-                         uint8_t abs_black_threshold);
+                         Interpolation interpolate_type);
 
 void resize_and_replace(Image *pImage, RectangleSize size,
-                        Interpolation interpolate_type, Pixel sheet_background,
-                        uint8_t abs_black_threshold);
+                        Interpolation interpolate_type);
 
 // Rotates an image clockwise or anti-clockwise in 90-degrees.
-void flip_rotate_90(Image *pImage, RotationDirection direction,
-                    uint8_t abs_black_threshold);
+void flip_rotate_90(Image *pImage, RotationDirection direction);
 
 // Mirrors an image either horizontally, vertically, or both.
-void mirror(Image image, bool horizontal, bool vertical,
-            uint8_t abs_black_threshold);
+void mirror(Image image, bool horizontal, bool vertical);
 
 // Shifts the image.
-void shift_image(Image *pImage, Delta d, Pixel sheet_background,
-                 uint8_t abs_black_threshold);
+void shift_image(Image *pImage, Delta d);

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -42,7 +42,7 @@ validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
  * @param m ascending slope of the virtually shifted (m=tan(angle)). Mind that
  * this is negative for negative radians.
  */
-static int detect_edge_rotation_peak(AVFrame *image, const Rectangle mask,
+static int detect_edge_rotation_peak(Image image, const Rectangle mask,
                                      const DeskewParameters params, Delta shift,
                                      float m) {
   RectangleSize size = size_of_rectangle(mask);
@@ -143,7 +143,7 @@ static int detect_edge_rotation_peak(AVFrame *image, const Rectangle mask,
  * bottom. Which of the four edges to take depends on whether shiftX or shiftY
  * is non-zero, and what sign this shifting value has.
  */
-static float detect_edge_rotation(AVFrame *image, const Rectangle mask,
+static float detect_edge_rotation(Image image, const Rectangle mask,
                                   const DeskewParameters params, Delta shift) {
   // either shiftX or shiftY is 0, the other value is -i|+i
   // depending on shiftX/shiftY the start edge for shifting is determined
@@ -170,7 +170,7 @@ static float detect_edge_rotation(AVFrame *image, const Rectangle mask,
  * either the horizontal or vertical edges of the area specified by left, top,
  * right, bottom.
  */
-float detect_rotation(AVFrame *image, const Rectangle mask,
+float detect_rotation(Image image, const Rectangle mask,
                       const DeskewParameters params) {
   float rotation[4];
   int count = 0;
@@ -242,18 +242,16 @@ float detect_rotation(AVFrame *image, const Rectangle mask,
  * middle-point. (To rotate parts of an image, extract the part with copyBuffer,
  * rotate, and re-paste with copyBuffer.)
  */
-void rotate(AVFrame *source, AVFrame *target, const float radians,
+void rotate(Image source, Image target, const float radians,
             uint8_t abs_black_threshold, Interpolation interpolate_type) {
   Rectangle source_area = full_image(source);
-
-  const int w = source->width;
-  const int h = source->height;
+  RectangleSize source_size = size_of_image(source);
 
   // create 2D rotation matrix
   const float sinval = sinf(radians);
   const float cosval = cosf(radians);
-  const float midX = w / 2.0f;
-  const float midY = h / 2.0f;
+  const float midX = source_size.width / 2.0f;
+  const float midY = source_size.height / 2.0f;
 
   scan_rectangle(source_area) {
     const float srcX = midX + (x - midX) * cosval + (y - midY) * sinval;

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 
+#include <libavutil/mathematics.h> // for M_PI
+
 #include "constants.h"
 #include "imageprocess/deskew.h"
 #include "imageprocess/interpolate.h"

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -245,7 +245,7 @@ float detect_rotation(Image image, const Rectangle mask,
  * rotate, and re-paste with copyBuffer.)
  */
 void rotate(Image source, Image target, const float radians,
-            uint8_t abs_black_threshold, Interpolation interpolate_type) {
+            Interpolation interpolate_type) {
   Rectangle source_area = full_image(source);
   RectangleSize source_size = size_of_image(source);
 
@@ -260,6 +260,6 @@ void rotate(Image source, Image target, const float radians,
     const float srcY = midY + (y - midY) * cosval - (x - midX) * sinval;
     const Pixel pxl =
         interpolate(source, (FloatPoint){srcX, srcY}, interpolate_type);
-    set_pixel(target, (Point){x, y}, pxl, abs_black_threshold);
+    set_pixel(target, (Point){x, y}, pxl);
   }
 }

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -31,4 +31,4 @@ float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);
 
 void rotate(Image source, Image target, const float radians,
-            uint8_t abs_black_threshold, Interpolation interpolate_type);
+            Interpolation interpolate_type);

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdint.h>
 
+#include "imageprocess/image.h"
 #include "imageprocess/interpolate.h"
 #include "imageprocess/primitives.h"
 
@@ -27,8 +27,8 @@ validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
                            float deskewScanDeviation, int deskewScanSize,
                            float deskewScanDepth, int deskewScanEdges);
 
-float detect_rotation(AVFrame *image, Rectangle mask,
+float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);
 
-void rotate(AVFrame *source, AVFrame *target, const float radians,
+void rotate(Image source, Image target, const float radians,
             uint8_t abs_black_threshold, Interpolation interpolate_type);

--- a/imageprocess/fill.c
+++ b/imageprocess/fill.c
@@ -15,7 +15,7 @@
  */
 static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
                           uint8_t mask_min, uint8_t mask_max,
-                          uint64_t intensity, uint8_t abs_black_threshold) {
+                          uint64_t intensity) {
   uint64_t distance = 0;
   uint64_t intensityCount =
       1; // first pixel must match, otherwise directly exit
@@ -37,7 +37,7 @@ static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
       return distance;
     }
 
-    set_pixel(image, p, color, abs_black_threshold);
+    set_pixel(image, p, color);
     distance++;
   }
 }
@@ -54,22 +54,21 @@ static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
 static void flood_fill_around_line(Image image, Point p, Delta step,
                                    uint64_t distance, Pixel color,
                                    uint8_t mask_min, uint8_t mask_max,
-                                   uint64_t intensity,
-                                   uint8_t abs_black_threshold) {
+                                   uint64_t intensity) {
   for (uint64_t d = 0; d < distance; d++) {
     if (step.horizontal != 0) {
       p.x += step.horizontal;
       // indirect recursion
       flood_fill(image, shift_point(p, DELTA_DOWNWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
       flood_fill(image, shift_point(p, DELTA_UPWARD), color, mask_min, mask_max,
-                 intensity, abs_black_threshold);
+                 intensity);
     } else { // step.vertical != 0
       p.y += step.vertical;
       flood_fill(image, shift_point(p, DELTA_RIGHTWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
       flood_fill(image, shift_point(p, DELTA_LEFTWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
     }
   }
 }
@@ -80,30 +79,29 @@ static void flood_fill_around_line(Image image, Point p, Delta step,
  * @see earlier header-declaration to enable indirect recursive calls
  */
 void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
-                uint8_t mask_max, uint64_t intensity,
-                uint8_t abs_black_threshold) {
+                uint8_t mask_max, uint64_t intensity) {
   // is current pixel to be filled?
   uint8_t pixel = get_pixel_grayscale(image, p);
   if ((pixel >= mask_min) && (pixel <= mask_max)) {
     // first, fill a 'cross' (both vertical, horizontal line)
-    set_pixel(image, p, color, abs_black_threshold);
+    set_pixel(image, p, color);
     const uint64_t left = fill_line(image, p, DELTA_LEFTWARD, color, mask_min,
-                                    mask_max, intensity, abs_black_threshold);
-    const uint64_t top = fill_line(image, p, DELTA_UPWARD, color, mask_min,
-                                   mask_max, intensity, abs_black_threshold);
+                                    mask_max, intensity);
+    const uint64_t top =
+        fill_line(image, p, DELTA_UPWARD, color, mask_min, mask_max, intensity);
     const uint64_t right = fill_line(image, p, DELTA_RIGHTWARD, color, mask_min,
-                                     mask_max, intensity, abs_black_threshold);
+                                     mask_max, intensity);
     const uint64_t bottom = fill_line(image, p, DELTA_DOWNWARD, color, mask_min,
-                                      mask_max, intensity, abs_black_threshold);
+                                      mask_max, intensity);
     // now recurse on each neighborhood-pixel of the cross (most recursions will
     // immediately return)
     flood_fill_around_line(image, p, DELTA_LEFTWARD, left, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_UPWARD, top, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_RIGHTWARD, right, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_DOWNWARD, bottom, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
   }
 }

--- a/imageprocess/fill.c
+++ b/imageprocess/fill.c
@@ -13,7 +13,7 @@
  * @param step_x either -1 or 1, if step_y is 0, else 0
  * @param step_y either -1 or 1, if step_x is 0, else 0
  */
-static uint64_t fill_line(AVFrame *image, Point p, Delta step, Pixel color,
+static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
                           uint8_t mask_min, uint8_t mask_max,
                           uint64_t intensity, uint8_t abs_black_threshold) {
   uint64_t distance = 0;
@@ -51,7 +51,7 @@ static uint64_t fill_line(AVFrame *image, Point p, Delta step, Pixel color,
  * @param step_y either -1 or 1, if step_x is 0, else 0
  * @see fillLine()
  */
-static void flood_fill_around_line(AVFrame *image, Point p, Delta step,
+static void flood_fill_around_line(Image image, Point p, Delta step,
                                    uint64_t distance, Pixel color,
                                    uint8_t mask_min, uint8_t mask_max,
                                    uint64_t intensity,
@@ -79,7 +79,7 @@ static void flood_fill_around_line(AVFrame *image, Point p, Delta step,
  *
  * @see earlier header-declaration to enable indirect recursive calls
  */
-void flood_fill(AVFrame *image, Point p, Pixel color, uint8_t mask_min,
+void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
                 uint8_t mask_max, uint64_t intensity,
                 uint8_t abs_black_threshold) {
   // is current pixel to be filled?

--- a/imageprocess/fill.h
+++ b/imageprocess/fill.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdint.h>
 
-#include "primitives.h"
+#include "imageprocess/primitives.h"
+#include "imageprocess/image.h"
 
-void flood_fill(AVFrame *image, Point p, Pixel color, uint8_t mask_min,
+void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
                 uint8_t mask_max, uint64_t intensity,
                 uint8_t abs_black_threshold);

--- a/imageprocess/fill.h
+++ b/imageprocess/fill.h
@@ -6,9 +6,8 @@
 
 #include <stdint.h>
 
-#include "imageprocess/primitives.h"
 #include "imageprocess/image.h"
+#include "imageprocess/primitives.h"
 
 void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
-                uint8_t mask_max, uint64_t intensity,
-                uint8_t abs_black_threshold);
+                uint8_t mask_max, uint64_t intensity);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -17,11 +17,12 @@
  * Blackfilter *
  ***************/
 
-BlackfilterParameters validate_blackfilter_parameters(
-    uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
-    uint32_t scan_step_v, uint32_t scan_depth_h, uint32_t scan_depth_v,
-    int8_t scan_directions, float threshold, int32_t intensity,
-    size_t exclusions_count, Rectangle *exclusions) {
+BlackfilterParameters
+validate_blackfilter_parameters(uint32_t scan_size_h, uint32_t scan_size_v,
+                                uint32_t scan_step_h, uint32_t scan_step_v,
+                                uint32_t scan_depth_h, uint32_t scan_depth_v,
+                                int8_t scan_directions, float threshold,
+                                int32_t intensity, const Masks *exclusions) {
   return (BlackfilterParameters){
       .scan_size =
           {
@@ -45,7 +46,6 @@ BlackfilterParameters validate_blackfilter_parameters(
       .abs_threshold = UINT8_MAX * threshold,
       .intensity = intensity,
 
-      .exclusions_count = exclusions_count,
       .exclusions = exclusions,
   };
 }
@@ -78,8 +78,8 @@ static void blackfilter_scan(Image image, BlackfilterParameters params,
 
       // If we find a solidly black area.
       if (blackness >= params.abs_threshold) {
-        if (!rectangle_overlap_any(area, params.exclusions_count,
-                                   params.exclusions)) {
+        if (!rectangle_overlap_any(area, params.exclusions->count,
+                                   params.exclusions->masks)) {
           verboseLog(VERBOSE_NORMAL, "black-area flood-fill: [%d,%d,%d,%d]\n",
                      area.vertex[0].x, area.vertex[0].y, area.vertex[1].x,
                      area.vertex[1].y);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 
 #include "constants.h"

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "imageprocess/image.h"
+#include "imageprocess/masks.h"
 #include "imageprocess/primitives.h"
 
 typedef struct {
@@ -28,17 +29,17 @@ typedef struct {
   uint8_t abs_threshold;
   int32_t intensity;
 
-  size_t exclusions_count;
-  Rectangle *exclusions;
+  const Masks *exclusions;
 } BlackfilterParameters;
 
 void blackfilter(Image image, BlackfilterParameters params);
 
-BlackfilterParameters validate_blackfilter_parameters(
-    uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
-    uint32_t scan_step_v, uint32_t scan_depth_h, uint32_t scan_depth_v,
-    int8_t scan_directions, float threshold, int32_t intensity,
-    size_t exclusions_count, Rectangle *exclusions);
+BlackfilterParameters
+validate_blackfilter_parameters(uint32_t scan_size_h, uint32_t scan_size_v,
+                                uint32_t scan_step_h, uint32_t scan_step_v,
+                                uint32_t scan_depth_h, uint32_t scan_depth_v,
+                                int8_t scan_directions, float threshold,
+                                int32_t intensity, const Masks *exclusions);
 
 typedef struct {
   RectangleSize scan_size;

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdint.h>
 
+#include "imageprocess/image.h"
 #include "imageprocess/primitives.h"
 
 typedef struct {
@@ -32,7 +32,7 @@ typedef struct {
   Rectangle *exclusions;
 } BlackfilterParameters;
 
-void blackfilter(AVFrame *image, BlackfilterParameters params,
+void blackfilter(Image image, BlackfilterParameters params,
                  uint8_t abs_black_threshold);
 
 BlackfilterParameters validate_blackfilter_parameters(
@@ -58,10 +58,10 @@ BlurfilterParameters validate_blurfilter_parameters(uint32_t scan_size_h,
                                                     uint32_t scan_step_v,
                                                     float intensity);
 
-uint64_t blurfilter(AVFrame *image, BlurfilterParameters params,
+uint64_t blurfilter(Image image, BlurfilterParameters params,
                     uint8_t abs_white_threshold, uint8_t abs_black_threshold);
 
-uint64_t noisefilter(AVFrame *image, uint64_t intensity,
+uint64_t noisefilter(Image image, uint64_t intensity,
                      uint8_t min_white_level, uint8_t abs_black_threshold);
 
 typedef struct {
@@ -81,5 +81,5 @@ GrayfilterParameters validate_grayfilter_parameters(uint32_t scan_size_h,
                                                     uint32_t scan_step_v,
                                                     float threshold);
 
-uint64_t grayfilter(AVFrame *image, GrayfilterParameters params,
+uint64_t grayfilter(Image image, GrayfilterParameters params,
                     uint8_t abs_black_threshold);

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -32,8 +32,7 @@ typedef struct {
   Rectangle *exclusions;
 } BlackfilterParameters;
 
-void blackfilter(Image image, BlackfilterParameters params,
-                 uint8_t abs_black_threshold);
+void blackfilter(Image image, BlackfilterParameters params);
 
 BlackfilterParameters validate_blackfilter_parameters(
     uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
@@ -59,10 +58,9 @@ BlurfilterParameters validate_blurfilter_parameters(uint32_t scan_size_h,
                                                     float intensity);
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
-                    uint8_t abs_white_threshold, uint8_t abs_black_threshold);
+                    uint8_t abs_white_threshold);
 
-uint64_t noisefilter(Image image, uint64_t intensity,
-                     uint8_t min_white_level, uint8_t abs_black_threshold);
+uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level);
 
 typedef struct {
   RectangleSize scan_size;
@@ -81,5 +79,4 @@ GrayfilterParameters validate_grayfilter_parameters(uint32_t scan_size_h,
                                                     uint32_t scan_step_v,
                                                     float threshold);
 
-uint64_t grayfilter(Image image, GrayfilterParameters params,
-                    uint8_t abs_black_threshold);
+uint64_t grayfilter(Image image, GrayfilterParameters params);

--- a/imageprocess/image.c
+++ b/imageprocess/image.c
@@ -34,8 +34,7 @@ Image create_image(RectangleSize size, int pixel_format, bool fill,
   }
 
   if (fill) {
-    wipe_rectangle(image, full_image(image), sheet_background,
-                   abs_black_threshold);
+    wipe_rectangle(image, full_image(image), image.background);
   }
 
   return image;

--- a/imageprocess/image.c
+++ b/imageprocess/image.c
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "imageprocess/image.h"
+#include "imageprocess/blit.h"
+#include "imageprocess/math_util.h"
+#include "imageprocess/pixel.h"
+#include "lib/logging.h"
+
+/**
+ * Allocates a memory block for storing image data and fills the AVFrame-struct
+ * with the specified values.
+ */
+Image create_image(RectangleSize size, int pixel_format, bool fill,
+                   Pixel sheet_background, uint8_t abs_black_threshold) {
+  Image image = {.frame = av_frame_alloc()};
+
+  image.frame->width = size.width;
+  image.frame->height = size.height;
+  image.frame->format = pixel_format;
+
+  int ret = av_frame_get_buffer(image.frame, 8);
+  if (ret < 0) {
+    char errbuff[1024];
+    av_strerror(ret, errbuff, sizeof(errbuff));
+    errOutput("unable to allocate buffer: %s", errbuff);
+  }
+
+  if (fill) {
+    wipe_rectangle(image, full_image(image), sheet_background,
+                   abs_black_threshold);
+  }
+
+  return image;
+}
+
+void replace_image(Image *image, Image *new_image) {
+  free_image(image);
+  image->frame = new_image->frame;
+  new_image->frame = NULL;
+}
+
+void free_image(Image *image) { av_frame_free(&image->frame); }
+
+RectangleSize size_of_image(Image image) {
+  return (RectangleSize){
+      .width = image.frame->width,
+      .height = image.frame->height,
+  };
+}
+
+Rectangle full_image(Image image) {
+  return rectangle_from_size(POINT_ORIGIN, size_of_image(image));
+}
+
+Rectangle clip_rectangle(Image image, Rectangle area) {
+  Rectangle normal_area = normalize_rectangle(area);
+
+  return (Rectangle){
+      .vertex =
+          {
+              {
+                  .x = max(normal_area.vertex[0].x, 0),
+                  .y = max(normal_area.vertex[0].y, 0),
+              },
+              {
+                  .x = min(normal_area.vertex[1].x, (image.frame->width - 1)),
+                  .y = min(normal_area.vertex[1].y, (image.frame->height - 1)),
+              },
+          },
+  };
+}

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -14,7 +14,8 @@ typedef struct {
   uint8_t abs_black_threshold;
 } Image;
 
-#define EMPTY_IMAGE (Image){NULL, PIXEL_WHITE, 0}
+#define EMPTY_IMAGE                                                            \
+  (Image) { NULL, PIXEL_WHITE, 0 }
 
 Image create_image(RectangleSize size, int pixel_format, bool fill,
                    Pixel sheet_background, uint8_t abs_black_threshold);

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2005 The unpaper authors
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+#pragma once
+
+#include "imageprocess/primitives.h"
+
+typedef struct AVFrame AVFrame;
+
+typedef struct {
+  AVFrame *frame;
+  Pixel background;
+  uint8_t abs_black_threshold;
+} Image;
+
+#define EMPTY_IMAGE (Image){NULL, PIXEL_WHITE, 0}
+
+Image create_image(RectangleSize size, int pixel_format, bool fill,
+                   Pixel sheet_background, uint8_t abs_black_threshold);
+void replace_image(Image *image, Image *new_image);
+void free_image(Image *image);
+
+RectangleSize size_of_image(Image image);
+Rectangle full_image(Image image);
+Rectangle clip_rectangle(Image image, Rectangle area);

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -20,6 +20,7 @@ Image create_image(RectangleSize size, int pixel_format, bool fill,
                    Pixel sheet_background, uint8_t abs_black_threshold);
 void replace_image(Image *image, Image *new_image);
 void free_image(Image *image);
+Image create_compatible_image(Image source, RectangleSize size, bool fill);
 
 RectangleSize size_of_image(Image image);
 Rectangle full_image(Image image);

--- a/imageprocess/interpolate.c
+++ b/imageprocess/interpolate.c
@@ -10,7 +10,7 @@
 #include "imageprocess/interpolate.h"
 #include "imageprocess/pixel.h"
 
-Pixel interp_nearest_neighbour(AVFrame *image, FloatPoint coords) {
+Pixel interp_nearest_neighbour(Image image, FloatPoint coords) {
   // Round to nearest location.
   Point p = {(int)roundf(coords.x), (int)roundf(coords.y)};
 
@@ -41,7 +41,7 @@ static Pixel cubic_pixel_interpolation(float factor, Pixel pxls[4]) {
 }
 
 // 2-D bicubic interpolation
-Pixel interp_bicubic(AVFrame *image, FloatPoint coords) {
+Pixel interp_bicubic(Image image, FloatPoint coords) {
   Point p = {(int)coords.x, (int)coords.y};
 
   Pixel pxls[4];
@@ -73,7 +73,7 @@ static Pixel linear_pixel_interpolation(float factor, Pixel a, Pixel b) {
 }
 
 // 2-D linear interpolation
-Pixel interp_bilinear(AVFrame *image, FloatPoint coords) {
+Pixel interp_bilinear(Image image, FloatPoint coords) {
   Rectangle image_area = full_image(image);
 
   Point p1 = {(int)floorf(coords.x), (int)floorf(coords.y)};
@@ -116,7 +116,7 @@ Pixel interp_bilinear(AVFrame *image, FloatPoint coords) {
   return linear_pixel_interpolation(coords.y - p1.y, pxl_h1, pxl_h2);
 }
 
-Pixel interpolate(AVFrame *image, FloatPoint coords, Interpolation function) {
+Pixel interpolate(Image image, FloatPoint coords, Interpolation function) {
   switch (function) {
   case INTERP_NN:
     return interp_nearest_neighbour(image, coords);

--- a/imageprocess/interpolate.h
+++ b/imageprocess/interpolate.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "imageprocess/image.h"
 #include "imageprocess/primitives.h"
 
 typedef struct {
@@ -18,4 +19,4 @@ typedef enum {
   INTERP_FUNCTIONS_COUNT
 } Interpolation;
 
-Pixel interpolate(AVFrame *image, FloatPoint coords, Interpolation function);
+Pixel interpolate(Image image, FloatPoint coords, Interpolation function);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/masks.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "imageprocess/blit.h"
+#include "imageprocess/masks.h"
 #include "imageprocess/pixel.h"
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
@@ -231,8 +235,7 @@ void center_mask(Image image, const Point center, const Rectangle area,
                area.vertex[0].x, area.vertex[0].y, area.vertex[1].x,
                area.vertex[1].y, center.x, center.y,
                target.x - area.vertex[0].x, target.y - area.vertex[0].y);
-    Image newimage = create_image(size, image.frame->format, false, PIXEL_WHITE,
-                                  abs_black_threshold);
+    Image newimage = create_compatible_image(image, size, false);
     copy_rectangle(image, newimage, area, POINT_ORIGIN, abs_black_threshold);
     wipe_rectangle(image, area, sheet_background, abs_black_threshold);
     copy_rectangle(newimage, image, full_image(newimage), target,
@@ -302,8 +305,7 @@ void align_mask(Image image, const Rectangle inside_area,
              target.y, target.x - inside_area.vertex[0].x,
              target.y - inside_area.vertex[0].y);
 
-  Image newimage = create_image(inside_size, image.frame->format, true,
-                                sheet_background, abs_black_threshold);
+  Image newimage = create_compatible_image(image, inside_size, true);
   copy_rectangle(image, newimage, inside_area, POINT_ORIGIN,
                  abs_black_threshold);
   wipe_rectangle(image, inside_area, sheet_background, abs_black_threshold);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -188,14 +188,14 @@ static const Rectangle INVALID_MASK = {{{-1, -1}, {-1, -1}}};
  */
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]) {
+                    Rectangle masks[]) {
   size_t masks_count = 0;
   if (!params.scan_horizontal && !params.scan_vertical) {
     return masks_count;
   }
 
   for (size_t i = 0; i < points_count; i++) {
-    mask_valid[i] = detect_mask(image, params, points[i], &masks[i]);
+    bool mask_valid = detect_mask(image, params, points[i], &masks[i]);
 
     // Compare the newly-detected mask with an invalid mask where all the
     // vertex are (-1, -1)
@@ -206,7 +206,7 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
           VERBOSE_NORMAL, "auto-masking (%d,%d): %d,%d,%d,%d%s\n", points[i].x,
           points[i].y, masks[i].vertex[0].x, masks[i].vertex[0].y,
           masks[i].vertex[1].x, masks[i].vertex[1].y,
-          mask_valid[i] ? "" : " (invalid detection, using full page size)");
+          mask_valid ? "" : " (invalid detection, using full page size)");
     } else {
       verboseLog(VERBOSE_NORMAL, "auto-masking (%d,%d): NO MASK FOUND\n",
                  points[i].x, points[i].y);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -6,11 +6,48 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <libavutil/common.h> // for av_log2
+
+#include "constants.h"
 #include "imageprocess/blit.h"
 #include "imageprocess/masks.h"
 #include "imageprocess/pixel.h"
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
+
+Masks create_mask_array() {
+  return (Masks){
+      .count = 0,
+      .masks = calloc(1, sizeof(Rectangle)),
+  };
+}
+
+bool append_mask(Masks *mask_array, Rectangle new_mask) {
+  // First check if we need to re-allocate the masks.
+  size_t allocated_log = av_log2(mask_array->count);
+  size_t allocated = (1 << allocated_log);
+  if (mask_array->count >= allocated) {
+    // Increase allocation in power-of-two steps, as other allocators would.
+    allocated *= 2;
+    if (allocated >= MAX_MASKS) {
+      return false;
+    }
+
+    mask_array->masks =
+        realloc(mask_array->masks, allocated * sizeof(Rectangle));
+  }
+
+  mask_array->masks[mask_array->count++] = new_mask;
+  return true;
+}
+
+void free_mask_array(Masks *mask_array) {
+  if (mask_array->count != 0) {
+    free(mask_array->masks);
+    mask_array->masks = NULL;
+    mask_array->count = 0;
+  }
+}
 
 MaskDetectionParameters
 validate_mask_detection_parameters(int scan_directions,
@@ -186,34 +223,39 @@ static const Rectangle INVALID_MASK = {{{-1, -1}, {-1, -1}}};
  *
  * @return number of masks stored in mask[][]
  */
-size_t detect_masks(Image image, MaskDetectionParameters params,
-                    const Point points[], size_t points_count,
-                    Rectangle masks[]) {
-  size_t masks_count = 0;
+Masks detect_masks(Image image, MaskDetectionParameters params,
+                   const Point points[], size_t points_count) {
+
+  Masks masks = create_mask_array();
   if (!params.scan_horizontal && !params.scan_vertical) {
-    return masks_count;
+    return masks;
   }
 
   for (size_t i = 0; i < points_count; i++) {
-    bool mask_valid = detect_mask(image, params, points[i], &masks[i]);
+    Rectangle detected_mask;
+    bool mask_valid = detect_mask(image, params, points[i], &detected_mask);
 
     // Compare the newly-detected mask with an invalid mask where all the
     // vertex are (-1, -1)
-    if (memcmp(&masks[i], &INVALID_MASK, sizeof(INVALID_MASK)) != 0) {
-      masks_count++;
+    if (memcmp(&detected_mask, &INVALID_MASK, sizeof(INVALID_MASK)) != 0) {
+      const char *error = "";
+      if (!append_mask(&masks, detected_mask)) {
+        error = " maximum number of masks (%d) exceeded, ignoring mask.";
+      }
 
-      verboseLog(
-          VERBOSE_NORMAL, "auto-masking (%d,%d): %d,%d,%d,%d%s\n", points[i].x,
-          points[i].y, masks[i].vertex[0].x, masks[i].vertex[0].y,
-          masks[i].vertex[1].x, masks[i].vertex[1].y,
-          mask_valid ? "" : " (invalid detection, using full page size)");
+      verboseLog(VERBOSE_NORMAL, "auto-masking (%d,%d): %d,%d,%d,%d%s%s\n",
+                 points[i].x, points[i].y, detected_mask.vertex[0].x,
+                 detected_mask.vertex[0].y, detected_mask.vertex[1].x,
+                 detected_mask.vertex[1].y,
+                 mask_valid ? "" : " (invalid detection, using full page size)",
+                 error);
     } else {
       verboseLog(VERBOSE_NORMAL, "auto-masking (%d,%d): NO MASK FOUND\n",
                  points[i].x, points[i].y);
     }
   }
 
-  return masks_count;
+  return masks;
 }
 
 /**
@@ -313,9 +355,8 @@ void align_mask(Image image, const Rectangle inside_area,
  * Permanently applies image masks. Each pixel which is not covered by at least
  * one mask is set to maskColor.
  */
-void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
-                 Pixel color) {
-  if (masks_count <= 0) {
+void apply_masks(Image image, Masks masks, Pixel color) {
+  if (masks.count <= 0) {
     return;
   }
 
@@ -323,7 +364,7 @@ void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
 
   scan_rectangle(image_area) {
     Point p = {x, y};
-    if (!point_in_rectangles_any(p, masks_count, masks)) {
+    if (!point_in_rectangles_any(p, masks.count, masks.masks)) {
       set_pixel(image, p, color);
     }
   }
@@ -333,20 +374,19 @@ void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
  * Permanently wipes out areas of an images. Each pixel covered by a wipe-area
  * is set to wipeColor.
  */
-void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
-                 Pixel color) {
-  for (size_t i = 0; i < wipes_count; i++) {
+void apply_wipes(Image image, Masks wipes, Pixel color) {
+  for (size_t i = 0; i < wipes.count; i++) {
     uint64_t count = 0;
 
-    scan_rectangle(wipes[i]) {
+    scan_rectangle(wipes.masks[i]) {
       if (set_pixel(image, (Point){x, y}, color)) {
         count++;
       }
     }
 
     verboseLog(VERBOSE_MORE, "wipe [%d,%d,%d,%d]: %" PRIu64 " pixels\n",
-               wipes[i].vertex[0].x, wipes[i].vertex[0].y, wipes[i].vertex[1].x,
-               wipes[i].vertex[1].y, count);
+               wipes.masks[i].vertex[0].x, wipes.masks[i].vertex[0].y,
+               wipes.masks[i].vertex[1].x, wipes.masks[i].vertex[1].y, count);
   }
 }
 
@@ -375,12 +415,15 @@ void apply_border(Image image, const Border border, Pixel color) {
     return;
   }
 
+  Masks masks = create_mask_array();
   Rectangle mask = border_to_mask(image, border);
+  append_mask(&masks, mask);
+
   verboseLog(VERBOSE_NORMAL, "applying border (%d,%d,%d,%d) [%d,%d,%d,%d]\n",
              border.left, border.top, border.right, border.bottom,
              mask.vertex[0].x, mask.vertex[0].y, mask.vertex[1].x,
              mask.vertex[1].y);
-  apply_masks(image, &mask, 1, color);
+  apply_masks(image, masks, color);
 }
 
 BorderScanParameters

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdbool.h>
 #include <stdint.h>
 
 #include "constants.h"
+#include "imageprocess/image.h"
 #include "imageprocess/primitives.h"
 
 typedef struct {
@@ -48,11 +48,11 @@ validate_mask_detection_parameters(int scan_directions,
                                    const int scan_mininum[DIMENSIONS_COUNT],
                                    const int scan_maximum[DIMENSIONS_COUNT]);
 
-size_t detect_masks(AVFrame *image, MaskDetectionParameters params,
+size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
                     bool mask_valid[], Rectangle masks[]);
 
-void center_mask(AVFrame *image, const Point center, const Rectangle area,
+void center_mask(Image image, const Point center, const Rectangle area,
                  Pixel sheet_background, uint8_t abs_black_threshold);
 
 typedef struct {
@@ -73,14 +73,14 @@ MaskAlignmentParameters
 validate_mask_alignment_parameters(int border_align,
                                    const int margin[DIRECTIONS_COUNT]);
 
-void align_mask(AVFrame *image, const Rectangle inside_area,
+void align_mask(Image image, const Rectangle inside_area,
                 const Rectangle outside, MaskAlignmentParameters params,
                 Pixel sheet_background, uint8_t abs_black_threshold);
 
-void apply_masks(AVFrame *image, const Rectangle masks[], size_t masks_count,
+void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
                  Pixel color, uint8_t abs_black_threshold);
 
-void apply_wipes(AVFrame *image, Rectangle wipes[], size_t wipes_count,
+void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
                  Pixel color, uint8_t abs_black_threshold);
 
 typedef struct {
@@ -92,8 +92,8 @@ typedef struct {
 
 static const Border BORDER_NULL = {0, 0, 0, 0};
 
-Rectangle border_to_mask(AVFrame *image, const Border border);
-void apply_border(AVFrame *image, const Border border, Pixel color,
+Rectangle border_to_mask(Image image, const Border border);
+void apply_border(Image image, const Border border, Pixel color,
                   uint8_t abs_black_threshold);
 
 typedef struct {
@@ -119,5 +119,5 @@ validate_border_scan_parameters(int scan_directions,
                                 const int scan_step[DIRECTIONS_COUNT],
                                 const int scan_threshold[DIRECTIONS_COUNT]);
 
-Border detect_border(AVFrame *image, BorderScanParameters params,
+Border detect_border(Image image, BorderScanParameters params,
                      const Rectangle outside_mask, uint8_t abs_black_threshold);

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -52,8 +52,7 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
                     bool mask_valid[], Rectangle masks[]);
 
-void center_mask(Image image, const Point center, const Rectangle area,
-                 Pixel sheet_background, uint8_t abs_black_threshold);
+void center_mask(Image image, const Point center, const Rectangle area);
 
 typedef struct {
   struct {
@@ -74,14 +73,13 @@ validate_mask_alignment_parameters(int border_align,
                                    const int margin[DIRECTIONS_COUNT]);
 
 void align_mask(Image image, const Rectangle inside_area,
-                const Rectangle outside, MaskAlignmentParameters params,
-                Pixel sheet_background, uint8_t abs_black_threshold);
+                const Rectangle outside, MaskAlignmentParameters params);
 
 void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
-                 Pixel color, uint8_t abs_black_threshold);
+                 Pixel color);
 
 void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
-                 Pixel color, uint8_t abs_black_threshold);
+                 Pixel color);
 
 typedef struct {
   int32_t left;
@@ -93,8 +91,7 @@ typedef struct {
 static const Border BORDER_NULL = {0, 0, 0, 0};
 
 Rectangle border_to_mask(Image image, const Border border);
-void apply_border(Image image, const Border border, Pixel color,
-                  uint8_t abs_black_threshold);
+void apply_border(Image image, const Border border, Pixel color);
 
 typedef struct {
   RectangleSize scan_size;
@@ -120,4 +117,4 @@ validate_border_scan_parameters(int scan_directions,
                                 const int scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,
-                     const Rectangle outside_mask, uint8_t abs_black_threshold);
+                     const Rectangle outside_mask);

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -50,7 +50,7 @@ validate_mask_detection_parameters(int scan_directions,
 
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]);
+                    Rectangle masks[]);
 
 void center_mask(Image image, const Point center, const Rectangle area);
 

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -12,6 +12,15 @@
 #include "imageprocess/primitives.h"
 
 typedef struct {
+  size_t count;
+  Rectangle *masks;
+} Masks;
+
+Masks create_mask_array();
+bool append_mask(Masks *mask_array, Rectangle new_mask);
+void free_mask_array(Masks *mask_array);
+
+typedef struct {
   RectangleSize scan_size;
 
   struct {
@@ -48,9 +57,8 @@ validate_mask_detection_parameters(int scan_directions,
                                    const int scan_mininum[DIMENSIONS_COUNT],
                                    const int scan_maximum[DIMENSIONS_COUNT]);
 
-size_t detect_masks(Image image, MaskDetectionParameters params,
-                    const Point points[], size_t points_count,
-                    Rectangle masks[]);
+Masks detect_masks(Image image, MaskDetectionParameters params,
+                   const Point points[], size_t points_count);
 
 void center_mask(Image image, const Point center, const Rectangle area);
 
@@ -75,11 +83,9 @@ validate_mask_alignment_parameters(int border_align,
 void align_mask(Image image, const Rectangle inside_area,
                 const Rectangle outside, MaskAlignmentParameters params);
 
-void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
-                 Pixel color);
+void apply_masks(Image image, Masks masks, Pixel color);
 
-void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
-                 Pixel color);
+void apply_wipes(Image image, Masks wipes, Pixel color);
 
 typedef struct {
   int32_t left;

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -147,8 +147,7 @@ uint8_t get_pixel_darkness_inverse(Image image, Point coords) {
  * @return true if the pixel has been changed, false if the original color was
  * the one to set
  */
-bool set_pixel(Image image, Point coords, Pixel pixel,
-               uint8_t abs_black_threshold) {
+bool set_pixel(Image image, Point coords, Pixel pixel) {
   uint8_t *pix;
 
   if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
@@ -156,7 +155,7 @@ bool set_pixel(Image image, Point coords, Pixel pixel,
     return false; // nop
   }
 
-  uint8_t pixelbw = pixel_grayscale(pixel) < abs_black_threshold
+  uint8_t pixelbw = pixel_grayscale(pixel) < image.abs_black_threshold
                         ? BLACK_COMPONENT
                         : WHITE_COMPONENT;
 

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -67,6 +67,21 @@ static Pixel get_pixel_components(AVFrame *image, Point coords,
   return pixel;
 }
 
+Pixel pixel_from_value(uint32_t value) {
+  return (Pixel){
+      .r = (value >> 16) & 0xff,
+      .g = (value >> 8) & 0xff,
+      .b = value & 0xff,
+  };
+}
+
+int compare_pixel(Pixel a, Pixel b) {
+  if (memcmp(&a, &b, sizeof(Pixel)) == 0) {
+    return 0;
+  }
+  return pixel_grayscale(a) < pixel_grayscale(b) ? -1 : 1;
+}
+
 /* Returns the color or grayscale value of a single pixel.
  * Always returns a color-compatible value (which may be interpreted as 8-bit
  * grayscale)

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -7,15 +7,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <libavutil/frame.h>
-
+#include "imageprocess/image.h"
 #include "imageprocess/primitives.h"
 
 Pixel pixel_from_value(uint32_t value);
 int compare_pixel(Pixel a, Pixel b);
-Pixel get_pixel(AVFrame *image, Point coords);
-uint8_t get_pixel_grayscale(AVFrame *image, Point coords);
-uint8_t get_pixel_lightness(AVFrame *image, Point coords);
-uint8_t get_pixel_darkness_inverse(AVFrame *image, Point coords);
-bool set_pixel(AVFrame *image, Point coords, Pixel pixel,
+Pixel get_pixel(Image image, Point coords);
+uint8_t get_pixel_grayscale(Image image, Point coords);
+uint8_t get_pixel_lightness(Image image, Point coords);
+uint8_t get_pixel_darkness_inverse(Image image, Point coords);
+bool set_pixel(Image image, Point coords, Pixel pixel,
                uint8_t abs_black_threshold);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -16,5 +16,4 @@ Pixel get_pixel(Image image, Point coords);
 uint8_t get_pixel_grayscale(Image image, Point coords);
 uint8_t get_pixel_lightness(Image image, Point coords);
 uint8_t get_pixel_darkness_inverse(Image image, Point coords);
-bool set_pixel(Image image, Point coords, Pixel pixel,
-               uint8_t abs_black_threshold);
+bool set_pixel(Image image, Point coords, Pixel pixel);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -11,6 +11,8 @@
 
 #include "imageprocess/primitives.h"
 
+Pixel pixel_from_value(uint32_t value);
+int compare_pixel(Pixel a, Pixel b);
 Pixel get_pixel(AVFrame *image, Point coords);
 uint8_t get_pixel_grayscale(AVFrame *image, Point coords);
 uint8_t get_pixel_lightness(AVFrame *image, Point coords);

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -64,33 +64,16 @@ Rectangle shift_rectangle(Rectangle rect, Delta d) {
   }};
 }
 
-RectangleSize size_of_image(AVFrame *image) {
-  return (RectangleSize){
-      .width = image->width,
-      .height = image->height,
-  };
-}
+int compare_sizes(RectangleSize a, RectangleSize b) {
+  if (a.height == b.height && a.width == b.width) {
+    return 0;
+  }
 
-Rectangle full_image(AVFrame *image) {
-  return rectangle_from_size(POINT_ORIGIN, size_of_image(image));
-}
-
-Rectangle clip_rectangle(AVFrame *image, Rectangle area) {
-  Rectangle normal_area = normalize_rectangle(area);
-
-  return (Rectangle){
-      .vertex =
-          {
-              {
-                  .x = max(normal_area.vertex[0].x, 0),
-                  .y = max(normal_area.vertex[0].y, 0),
-              },
-              {
-                  .x = min(normal_area.vertex[1].x, (image->width - 1)),
-                  .y = min(normal_area.vertex[1].y, (image->height - 1)),
-              },
-          },
-  };
+  if (min(a.height, a.width) < min(b.height, b.width)) {
+    return -1;
+  } else {
+    return 1;
+  }
 }
 
 uint64_t count_pixels(Rectangle area) {

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -4,8 +4,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/primitives.h"
+#include <stdlib.h>
+
 #include "imageprocess/math_util.h"
+#include "imageprocess/primitives.h"
 
 Delta distance_between(Point a, Point b) {
   return (Delta){

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -65,10 +65,7 @@ Rectangle rectangle_from_size(Point origin, RectangleSize size);
 RectangleSize size_of_rectangle(Rectangle rect);
 Rectangle normalize_rectangle(Rectangle input);
 Rectangle shift_rectangle(Rectangle rect, Delta d);
-
-RectangleSize size_of_image(AVFrame *image);
-Rectangle full_image(AVFrame *image);
-Rectangle clip_rectangle(AVFrame *image, Rectangle area);
+int compare_sizes(RectangleSize a, RectangleSize b);
 
 uint64_t count_pixels(Rectangle area);
 

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -44,7 +44,9 @@ typedef struct {
 } Pixel;
 
 #define PIXEL_WHITE                                                            \
-  (Pixel) { 0xFF, 0xFF, 0xFF }
+  (Pixel) { UINT8_MAX, UINT8_MAX, UINT8_MAX }
+#define PIXEL_BLACK                                                            \
+  (Pixel) { 0, 0, 0 }
 
 typedef struct {
   Point vertex[2];

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {

--- a/lib/options.c
+++ b/lib/options.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/lib/options.c
+++ b/lib/options.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "imageprocess/pixel.h"
 #include "lib/options.h"
 
 static struct MultiIndex multi_index_empty(void) {
@@ -56,4 +57,34 @@ int print_rectangle(Rectangle rect) {
   return printf("[%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 "] ",
                 rect.vertex[0].x, rect.vertex[0].y, rect.vertex[1].x,
                 rect.vertex[1].y);
+}
+
+bool parse_color(const char *str, Pixel *color) {
+  if (strcmp(str, "black") == 0) {
+    *color = PIXEL_BLACK;
+    return true;
+  }
+  if (strcmp(str, "white") == 0) {
+    *color = PIXEL_WHITE;
+    return true;
+  }
+
+  uint32_t colorValue;
+  if (sscanf(str, "%" SCNd32, &colorValue) != 1) {
+    return false;
+  }
+
+  *color = pixel_from_value(colorValue);
+  return true;
+}
+
+int print_color(Pixel color) {
+  if (compare_pixel(color, PIXEL_BLACK) == 0) {
+    return printf("black");
+  }
+  if (compare_pixel(color, PIXEL_WHITE) == 0) {
+    return printf("white");
+  }
+
+  return printf("#%02x%02x%02x", color.r, color.g, color.b);
 }

--- a/lib/options.h
+++ b/lib/options.h
@@ -43,3 +43,6 @@ void options_init(Options *o);
 
 bool parse_rectangle(const char *str, Rectangle *rect);
 int print_rectangle(Rectangle rect);
+
+bool parse_color(const char *str, Pixel *color);
+int print_color(Pixel color);

--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ unpaper = executable(
     'imageprocess/interpolate.c',
     'imageprocess/fill.c',
     'imageprocess/filters.c',
+    'imageprocess/image.c',
     'imageprocess/masks.c',
     'imageprocess/pixel.c',
     'imageprocess/primitives.c',

--- a/parse.c
+++ b/parse.c
@@ -210,18 +210,6 @@ void parseSize(char *s, int i[2], int dpi) {
 }
 
 /**
- * Parses a color. Currently only "black" and "white".
- */
-int parseColor(char *s) {
-  if (strcmp(s, "black") == 0)
-    return BLACK24;
-  if (strcmp(s, "white") == 0)
-    return WHITE24;
-
-  errOutput("cannot parse color '%s'.", s);
-}
-
-/**
  * Parses either a single float string, of a pair of two floats separated
  * by a comma.
  */

--- a/parse.h
+++ b/parse.h
@@ -22,8 +22,6 @@ void parseInts(char *s, int i[2]);
 
 void parseSize(char *s, int i[2], int dpi);
 
-int parseColor(char *s);
-
 void parseFloats(char *s, float f[2]);
 
 char *implode(char *buf, const char *s[], int cnt);

--- a/unpaper.c
+++ b/unpaper.c
@@ -234,7 +234,6 @@ int main(int argc, char *argv[]) {
   Border preBorder = {0, 0, 0, 0};
   Border postBorder = {0, 0, 0, 0};
   Border border = {0, 0, 0, 0};
-  bool maskValid[MAX_MASKS];
   float whiteThreshold = 0.9;
   float blackThreshold = 0.33;
   bool writeoutput = true;
@@ -579,7 +578,6 @@ int main(int argc, char *argv[]) {
     case 'm':
       if (maskCount < MAX_MASKS) {
         if (parse_rectangle(optarg, &masks[maskCount])) {
-          maskValid[maskCount] = true;
           maskCount++;
         }
       } else {
@@ -1675,8 +1673,7 @@ int main(int argc, char *argv[]) {
       // mask-detection
       if (!isExcluded(nr, options.no_mask_scan_multi_index,
                       options.ignore_multi_index)) {
-        detect_masks(sheet, maskDetectionParams, points, pointCount, maskValid,
-                     masks);
+        detect_masks(sheet, maskDetectionParams, points, pointCount, masks);
       } else {
         verboseLog(VERBOSE_MORE, "+ mask-scan DISABLED for sheet %d\n", nr);
       }
@@ -1712,7 +1709,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before deskewing disabled)\n");
         }
@@ -1764,7 +1761,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }

--- a/unpaper.c
+++ b/unpaper.c
@@ -1755,12 +1755,10 @@ int main(int argc, char *argv[]) {
                      points[i].y, rotation);
 
           if (rotation != 0.0) {
-            Image rect =
-                create_image(size_of_rectangle(masks[i]), sheet.frame->format,
-                             false, sheetBackgroundPixel, absBlackThreshold);
-            Image rectTarget =
-                create_image(size_of_image(rect), sheet.frame->format, true,
-                             sheetBackgroundPixel, absBlackThreshold);
+            Image rect = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), false);
+            Image rectTarget = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), true);
 
             // copy area to rotate into rSource
             copy_rectangle(sheet, rect,
@@ -1949,11 +1947,11 @@ int main(int argc, char *argv[]) {
 
         for (int j = 0; j < options.output_count; j++) {
           // get pagebuffer
-          page = create_image(
+          page = create_compatible_image(
+              sheet,
               (RectangleSize){sheet.frame->width / options.output_count,
                               sheet.frame->height},
-              sheet.frame->format, false, sheetBackgroundPixel,
-              absBlackThreshold);
+              false);
           copy_rectangle(
               sheet, page,
               (Rectangle){{{page.frame->width * j, 0},

--- a/unpaper.c
+++ b/unpaper.c
@@ -176,14 +176,13 @@ int main(int argc, char *argv[]) {
   BorderScanParameters borderScanParams;
   int borderAlign = 0;                              // center
   int borderAlignMargin[DIRECTIONS_COUNT] = {0, 0}; // center
-  Pixel maskColorPixel;
+  Pixel maskColorPixel = PIXEL_WHITE;
   size_t pointCount = 0;
   Point points[MAX_POINTS];
   size_t maskCount = 0;
   Rectangle masks[MAX_MASKS];
   size_t preMaskCount = 0;
   Rectangle preMasks[MAX_MASKS];
-  int maskColor = WHITE24;
   size_t wipeCount = 0;
   Rectangle wipe[MAX_MASKS];
   int middleWipe[2] = {0, 0};
@@ -214,12 +213,11 @@ int main(int argc, char *argv[]) {
 
   Interpolation interpolateType = INTERP_CUBIC;
 
-  Pixel sheetBackgroundPixel;
+  Pixel sheetBackgroundPixel = PIXEL_WHITE;
   unsigned int absBlackThreshold;
   unsigned int absWhiteThreshold;
 
   int sheetSize[DIMENSIONS_COUNT] = {-1, -1};
-  int sheetBackground = WHITE24;
   int preRotate = 0;
   int postRotate = 0;
   int preMirror = 0;
@@ -475,7 +473,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_SHEET_BACKGROUND:
-      sheetBackground = parseColor(optarg);
+      if (!parse_color(optarg, &sheetBackgroundPixel)) {
+        errOutput("invalid value for sheet-background: %s", optarg);
+      }
       break;
 
     case 'x':
@@ -761,7 +761,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_MASK_COLOR:
-      sscanf(optarg, "%d", &maskColor);
+      if (!parse_color(optarg, &maskColorPixel)) {
+        errOutput("invalid value for mask-color: %s", optarg);
+      }
       break;
 
     case OPT_NO_MASK_CENTER:
@@ -966,8 +968,6 @@ int main(int argc, char *argv[]) {
     options.end_sheet = options.start_sheet;
 
   // Calculate the constant absolute values based on the relative parameters.
-  sheetBackgroundPixel = pixelValueToPixel(sheetBackground);
-  maskColorPixel = pixelValueToPixel(maskColor);
   absBlackThreshold = WHITE * (1.0 - blackThreshold);
   absWhiteThreshold = WHITE * (whiteThreshold);
 
@@ -1368,7 +1368,9 @@ int main(int argc, char *argv[]) {
                  maskScanMinimum[1]);
           printf("mask-scan-maximum: [%d,%d]\n", maskScanMaximum[0],
                  maskScanMaximum[1]);
-          printf("mask-color: %d\n", maskColor);
+          printf("mask-color: ");
+          print_color(maskColorPixel);
+          printf("\n");
           if (options.no_mask_scan_multi_index.count > 0) {
             printf("mask-scan DISABLED for sheets: ");
             printMultiIndex(options.no_mask_scan_multi_index);
@@ -1459,9 +1461,9 @@ int main(int argc, char *argv[]) {
         //}
         printf("white-threshold: %f\n", whiteThreshold);
         printf("black-threshold: %f\n", blackThreshold);
-        printf("sheet-background: %s %6x\n",
-               ((sheetBackground == BLACK24) ? "black" : "white"),
-               sheetBackground);
+        printf("sheet-background: ");
+        print_color(sheetBackgroundPixel);
+        printf("\n");
         printf("dpi: %d\n", dpi);
         printf("input-files per sheet: %d\n", options.input_count);
         printf("output-files per sheet: %d\n", options.output_count);

--- a/unpaper.c
+++ b/unpaper.c
@@ -1124,8 +1124,7 @@ int main(int argc, char *argv[]) {
 
           loadImage(inputFileNames[j], &page, sheetBackgroundPixel,
                     absBlackThreshold);
-          saveDebug("_loaded_%d.pnm", inputNr - options.input_count + j, page,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_loaded_%d.pnm", inputNr - options.input_count + j, page);
 
           if (outputPixFmt == -1 && page.frame != NULL) {
             outputPixFmt = page.frame->format;
@@ -1135,7 +1134,7 @@ int main(int argc, char *argv[]) {
           if (preRotate != 0) {
             verboseLog(VERBOSE_NORMAL, "pre-rotating %d degrees.\n", preRotate);
 
-            flip_rotate_90(&page, preRotate / 90, absBlackThreshold);
+            flip_rotate_90(&page, preRotate / 90);
           }
 
           // if sheet-size is not known yet (and not forced by --sheet-size),
@@ -1165,19 +1164,15 @@ int main(int argc, char *argv[]) {
                                sheetBackgroundPixel, absBlackThreshold);
         }
         if (page.frame != NULL) {
-          saveDebug("_page%d.pnm", inputNr - options.input_count + j, page,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_page%d.pnm", inputNr - options.input_count + j, page);
           saveDebug("_before_center_page%d.pnm",
-                    inputNr - options.input_count + j, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+                    inputNr - options.input_count + j, sheet);
 
           center_image(page, sheet, (Point){(w * j / options.input_count), 0},
-                       (RectangleSize){(w / options.input_count), h},
-                       sheetBackgroundPixel, absBlackThreshold);
+                       (RectangleSize){(w / options.input_count), h});
 
           saveDebug("_after_center_page%d.pnm",
-                    inputNr - options.input_count + j, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+                    inputNr - options.input_count + j, sheet);
         }
       }
 
@@ -1209,7 +1204,7 @@ int main(int argc, char *argv[]) {
                    getDirections(preMirror));
 
         mirror(sheet, !!(preMirror & (1 << HORIZONTAL)),
-               !!(preMirror & (1 << VERTICAL)), absBlackThreshold);
+               !!(preMirror & (1 << VERTICAL)));
       }
 
       // pre-shifting
@@ -1217,16 +1212,14 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "pre-shifting [%d,%d]\n", preShift[WIDTH],
                    preShift[HEIGHT]);
 
-        shift_image(&sheet, (Delta){preShift[WIDTH], preShift[HEIGHT]},
-                    sheetBackgroundPixel, absBlackThreshold);
+        shift_image(&sheet, (Delta){preShift[WIDTH], preShift[HEIGHT]});
       }
 
       // pre-masking
       if (preMaskCount > 0) {
         verboseLog(VERBOSE_NORMAL, "pre-masking\n ");
 
-        apply_masks(sheet, preMasks, preMaskCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_masks(sheet, preMasks, preMaskCount, maskColorPixel);
       }
 
       // --------------------------------------------------------------
@@ -1513,12 +1506,9 @@ int main(int argc, char *argv[]) {
       w *= zoomFactor;
       h *= zoomFactor;
 
-      saveDebug("_before-stretch%d.pnm", nr, sheet, sheetBackgroundPixel,
-                absBlackThreshold);
-      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                          absBlackThreshold);
-      saveDebug("_after-stretch%d.pnm", nr, sheet, sheetBackgroundPixel,
-                absBlackThreshold);
+      saveDebug("_before-stretch%d.pnm", nr, sheet);
+      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
+      saveDebug("_after-stretch%d.pnm", nr, sheet);
 
       // size
       if ((size[WIDTH] != -1) || (size[HEIGHT] != -1)) {
@@ -1532,12 +1522,9 @@ int main(int argc, char *argv[]) {
         } else {
           h = sheet.frame->height;
         }
-        saveDebug("_before-resize%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                           sheetBackgroundPixel, absBlackThreshold);
-        saveDebug("_after-resize%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-resize%d.pnm", nr, sheet);
+        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
+        saveDebug("_after-resize%d.pnm", nr, sheet);
       }
 
       // handle sheet layout
@@ -1634,24 +1621,21 @@ int main(int argc, char *argv[]) {
       // pre-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, preWipe, preWipeCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_wipes(sheet, preWipe, preWipeCount, maskColorPixel);
       }
 
       // pre-border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, preBorder, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, preBorder, maskColorPixel);
       }
 
       // black area filter
       if (!isExcluded(nr, options.no_blackfilter_multi_index,
                       options.ignore_multi_index)) {
-        saveDebug("_before-blackfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        blackfilter(sheet, blackfilterParams, absBlackThreshold);
-        saveDebug("_after-blackfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-blackfilter%d.pnm", nr, sheet);
+        blackfilter(sheet, blackfilterParams);
+        saveDebug("_after-blackfilter%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ blackfilter DISABLED for sheet %d\n", nr);
       }
@@ -1661,12 +1645,10 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "noise-filter ...");
 
-        saveDebug("_before-noisefilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult = noisefilter(
-            sheet, noisefilterIntensity, absWhiteThreshold, absBlackThreshold);
-        saveDebug("_after-noisefilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-noisefilter%d.pnm", nr, sheet);
+        uint64_t filterResult =
+            noisefilter(sheet, noisefilterIntensity, absWhiteThreshold);
+        saveDebug("_after-noisefilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRId64 " clusters.\n",
                    filterResult);
 
@@ -1679,12 +1661,10 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "blur-filter...");
 
-        saveDebug("_before-blurfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult = blurfilter(
-            sheet, blurfilterParams, absWhiteThreshold, absBlackThreshold);
-        saveDebug("_after-blurfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-blurfilter%d.pnm", nr, sheet);
+        uint64_t filterResult =
+            blurfilter(sheet, blurfilterParams, absWhiteThreshold);
+        saveDebug("_after-blurfilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
                    filterResult);
 
@@ -1703,11 +1683,9 @@ int main(int argc, char *argv[]) {
 
       // permanently apply masks
       if (maskCount > 0) {
-        saveDebug("_before-masking%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        apply_masks(sheet, masks, maskCount, maskColorPixel, absBlackThreshold);
-        saveDebug("_after-masking%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-masking%d.pnm", nr, sheet);
+        apply_masks(sheet, masks, maskCount, maskColorPixel);
+        saveDebug("_after-masking%d.pnm", nr, sheet);
       }
 
       // gray filter
@@ -1715,12 +1693,9 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "gray-filter...");
 
-        saveDebug("_before-grayfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult =
-            grayfilter(sheet, grayfilterParams, absBlackThreshold);
-        saveDebug("_after-grayfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-grayfilter%d.pnm", nr, sheet);
+        uint64_t filterResult = grayfilter(sheet, grayfilterParams);
+        saveDebug("_after-grayfilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
                    filterResult);
       } else {
@@ -1730,8 +1705,7 @@ int main(int argc, char *argv[]) {
       // rotation-detection
       if ((!isExcluded(nr, options.no_deskew_multi_index,
                        options.ignore_multi_index))) {
-        saveDebug("_before-deskew%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-deskew%d.pnm", nr, sheet);
 
         // detect masks again, we may get more precise results now after first
         // masking and grayfilter
@@ -1745,11 +1719,9 @@ int main(int argc, char *argv[]) {
 
         // auto-deskew each mask
         for (int i = 0; i < maskCount; i++) {
-          saveDebug("_before-deskew-detect%d.pnm", nr * maskCount + i, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_before-deskew-detect%d.pnm", nr * maskCount + i, sheet);
           float rotation = detect_rotation(sheet, masks[i], deskewParams);
-          saveDebug("_after-deskew-detect%d.pnm", nr * maskCount + i, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_after-deskew-detect%d.pnm", nr * maskCount + i, sheet);
 
           verboseLog(VERBOSE_NORMAL, "rotate (%d,%d): %f\n", points[i].x,
                      points[i].y, rotation);
@@ -1763,23 +1735,21 @@ int main(int argc, char *argv[]) {
             // copy area to rotate into rSource
             copy_rectangle(sheet, rect,
                            (Rectangle){{masks[i].vertex[0], POINT_INFINITY}},
-                           POINT_ORIGIN, absBlackThreshold);
+                           POINT_ORIGIN);
 
             // rotate
-            rotate(rect, rectTarget, -rotation, absBlackThreshold,
-                   interpolateType);
+            rotate(rect, rectTarget, -rotation, interpolateType);
 
             // copy result back into whole image
             copy_rectangle(rectTarget, sheet, full_image(rectTarget),
-                           masks[i].vertex[0], absBlackThreshold);
+                           masks[i].vertex[0]);
 
             free_image(&rect);
             free_image(&rectTarget);
           }
         }
 
-        saveDebug("_after-deskew%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-deskew%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ deskewing DISABLED for sheet %d\n", nr);
       }
@@ -1799,15 +1769,12 @@ int main(int argc, char *argv[]) {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }
 
-        saveDebug("_before-centering%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-centering%d.pnm", nr, sheet);
         // center masks on the sheet, according to their page position
         for (int i = 0; i < maskCount; i++) {
-          center_mask(sheet, points[i], masks[i], sheetBackgroundPixel,
-                      absBlackThreshold);
+          center_mask(sheet, points[i], masks[i]);
         }
-        saveDebug("_after-centering%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-centering%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ auto-centering DISABLED for sheet %d\n",
                    nr);
@@ -1816,7 +1783,7 @@ int main(int argc, char *argv[]) {
       // explicit wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, wipe, wipeCount, maskColorPixel, absBlackThreshold);
+        apply_wipes(sheet, wipe, wipeCount, maskColorPixel);
       } else {
         verboseLog(VERBOSE_MORE, "+ wipe DISABLED for sheet %d\n", nr);
       }
@@ -1824,7 +1791,7 @@ int main(int argc, char *argv[]) {
       // explicit border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, border, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, border, maskColorPixel);
       } else {
         verboseLog(VERBOSE_MORE, "+ border DISABLED for sheet %d\n", nr);
       }
@@ -1833,30 +1800,26 @@ int main(int argc, char *argv[]) {
       if (!isExcluded(nr, options.no_border_scan_multi_index,
                       options.ignore_multi_index)) {
         Rectangle autoborderMask[outsideBorderscanMaskCount];
-        saveDebug("_before-border%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-border%d.pnm", nr, sheet);
         for (int i = 0; i < outsideBorderscanMaskCount; i++) {
           autoborderMask[i] =
               border_to_mask(sheet, detect_border(sheet, borderScanParams,
-                                                  outsideBorderscanMask[i],
-                                                  absBlackThreshold));
+                                                  outsideBorderscanMask[i]));
         }
         apply_masks(sheet, autoborderMask, outsideBorderscanMaskCount,
-                    maskColorPixel, absBlackThreshold);
+                    maskColorPixel);
         for (int i = 0; i < outsideBorderscanMaskCount; i++) {
           // border-centering
           if (!isExcluded(nr, options.no_border_align_multi_index,
                           options.ignore_multi_index)) {
             align_mask(sheet, autoborderMask[i], outsideBorderscanMask[i],
-                       maskAlignmentParams, sheetBackgroundPixel,
-                       absBlackThreshold);
+                       maskAlignmentParams);
           } else {
             verboseLog(VERBOSE_MORE,
                        "+ border-centering DISABLED for sheet %d\n", nr);
           }
         }
-        saveDebug("_after-border%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-border%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ border-scan DISABLED for sheet %d\n", nr);
       }
@@ -1864,14 +1827,13 @@ int main(int argc, char *argv[]) {
       // post-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, postWipe, postWipeCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_wipes(sheet, postWipe, postWipeCount, maskColorPixel);
       }
 
       // post-border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, postBorder, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, postBorder, maskColorPixel);
       }
 
       // post-mirroring
@@ -1879,7 +1841,7 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "post-mirroring %s\n",
                    getDirections(postMirror));
         mirror(sheet, !!(postMirror & (1 << HORIZONTAL)),
-               !!(postMirror & (1 << VERTICAL)), absBlackThreshold);
+               !!(postMirror & (1 << VERTICAL)));
       }
 
       // post-shifting
@@ -1887,14 +1849,13 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "post-shifting [%d,%d]\n", postShift[WIDTH],
                    postShift[HEIGHT]);
 
-        shift_image(&sheet, (Delta){postShift[WIDTH], postShift[HEIGHT]},
-                    sheetBackgroundPixel, absBlackThreshold);
+        shift_image(&sheet, (Delta){postShift[WIDTH], postShift[HEIGHT]});
       }
 
       // post-rotating
       if (postRotate != 0) {
         verboseLog(VERBOSE_NORMAL, "post-rotating %d degrees.\n", postRotate);
-        flip_rotate_90(&sheet, postRotate / 90, absBlackThreshold);
+        flip_rotate_90(&sheet, postRotate / 90);
       }
 
       // post-stretch
@@ -1912,8 +1873,7 @@ int main(int argc, char *argv[]) {
       w *= postZoomFactor;
       h *= postZoomFactor;
 
-      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                          absBlackThreshold);
+      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
 
       // post-size
       if ((postSize[WIDTH] != -1) || (postSize[HEIGHT] != -1)) {
@@ -1927,8 +1887,7 @@ int main(int argc, char *argv[]) {
         } else {
           h = sheet.frame->height;
         }
-        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                           sheetBackgroundPixel, absBlackThreshold);
+        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
       }
 
       // --- write output file ---
@@ -1938,8 +1897,7 @@ int main(int argc, char *argv[]) {
       if (writeoutput == true) {
         verboseLog(VERBOSE_NORMAL, "writing output.\n");
         // write files
-        saveDebug("_before-save%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-save%d.pnm", nr, sheet);
 
         if (outputPixFmt == -1) {
           outputPixFmt = sheet.frame->format;
@@ -1957,12 +1915,11 @@ int main(int argc, char *argv[]) {
               (Rectangle){{{page.frame->width * j, 0},
                            {page.frame->width * j + page.frame->width,
                             page.frame->height}}},
-              POINT_ORIGIN, absBlackThreshold);
+              POINT_ORIGIN);
 
           verboseLog(VERBOSE_MORE, "saving file %s.\n", outputFileNames[j]);
 
-          saveImage(outputFileNames[j], page, outputPixFmt,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveImage(outputFileNames[j], page, outputPixFmt);
 
           free_image(&page);
         }

--- a/unpaper.c
+++ b/unpaper.c
@@ -180,17 +180,12 @@ int main(int argc, char *argv[]) {
   Pixel maskColorPixel = PIXEL_WHITE;
   size_t pointCount = 0;
   Point points[MAX_POINTS];
-  size_t maskCount = 0;
-  Rectangle masks[MAX_MASKS];
-  size_t preMaskCount = 0;
-  Rectangle preMasks[MAX_MASKS];
-  size_t wipeCount = 0;
-  Rectangle wipe[MAX_MASKS];
+  Masks masks = create_mask_array();
+  Masks preMasks = create_mask_array();
+  Masks wipe = create_mask_array();
   int middleWipe[2] = {0, 0};
-  size_t preWipeCount = 0;
-  Rectangle preWipe[MAX_MASKS];
-  size_t postWipeCount = 0;
-  Rectangle postWipe[MAX_MASKS];
+  Masks preWipe = create_mask_array();
+  Masks postWipe = create_mask_array();
   Rectangle outsideBorderscanMask[MAX_PAGES]; // set by --layout
   size_t outsideBorderscanMaskCount = 0;
   int blackfilterScanDirections = (1 << HORIZONTAL) | (1 << VERTICAL);
@@ -198,8 +193,7 @@ int main(int argc, char *argv[]) {
   int blackfilterScanDepth[DIRECTIONS_COUNT] = {500, 500};
   int blackfilterScanStep[DIRECTIONS_COUNT] = {5, 5};
   float blackfilterScanThreshold = 0.95;
-  size_t blackfilterExcludeCount = 0;
-  Rectangle blackfilterExclude[MAX_MASKS];
+  Masks blackfilterExclude = create_mask_array();
   int blackfilterIntensity = 20;
   BlackfilterParameters blackfilterParams;
   int blurfilterScanSize[DIRECTIONS_COUNT] = {100, 100};
@@ -422,6 +416,8 @@ int main(int argc, char *argv[]) {
     if (c == -1)
       break;
 
+    Rectangle tmpRectArg;
+
     switch (c) {
     case 'h':
     case '?':
@@ -526,14 +522,13 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_PRE_MASK:
-      if (preMaskCount < MAX_MASKS) {
-        if (parse_rectangle(optarg, &preMasks[preMaskCount])) {
-          preMaskCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&preMasks, tmpRectArg)) {
+          fprintf(
+              stderr,
+              "maximum number of pre-masks (%d) exceeded, ignoring mask %s\n",
+              MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(stderr,
-                "maximum number of masks (%d) exceeded, ignoring mask %s\n",
-                MAX_MASKS, optarg);
       }
       break;
 
@@ -576,51 +571,44 @@ int main(int argc, char *argv[]) {
       break;
 
     case 'm':
-      if (maskCount < MAX_MASKS) {
-        if (parse_rectangle(optarg, &masks[maskCount])) {
-          maskCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&masks, tmpRectArg)) {
+          fprintf(stderr,
+                  "maximum number of masks (%d) exceeded, ignoring mask %s\n",
+                  MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(stderr,
-                "maximum number of masks (%d) exceeded, ignoring mask %s\n",
-                MAX_MASKS, optarg);
       }
       break;
 
     case 'W':
-      if (wipeCount < MAX_MASKS) {
-        if (parse_rectangle(optarg, &wipe[wipeCount])) {
-          wipeCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&wipe, tmpRectArg)) {
+          fprintf(stderr,
+                  "maximum number of wipes (%d) exceeded, ignoring mask %s\n",
+                  MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(stderr,
-                "maximum number of wipes (%d) exceeded, ignoring mask %s\n",
-                MAX_MASKS, optarg);
       }
       break;
 
     case OPT_PRE_WIPE:
-      if (preWipeCount < MAX_MASKS) {
-        if (parse_rectangle(optarg, &preWipe[preWipeCount])) {
-          preWipeCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&preWipe, tmpRectArg)) {
+          fprintf(
+              stderr,
+              "maximum number of pre-wipes (%d) exceeded, ignoring mask %s\n",
+              MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(stderr,
-                "maximum number of pre-wipes (%d) exceeded, ignoring mask %s\n",
-                MAX_MASKS, optarg);
       }
       break;
 
     case OPT_POST_WIPE:
-      if (postWipeCount < MAX_MASKS) {
-        if (parse_rectangle(optarg, &postWipeCount[postWipe])) {
-          postWipeCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&postWipe, tmpRectArg)) {
+          fprintf(
+              stderr,
+              "maximum number of post-wipes (%d) exceeded, ignoring mask %s\n",
+              MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(
-            stderr,
-            "maximum number of post-wipes (%d) exceeded, ignoring mask %s\n",
-            MAX_MASKS, optarg);
       }
       break;
 
@@ -668,16 +656,13 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_BLACK_FILTER_SCAN_EXCLUDE:
-      if (blackfilterExcludeCount < MAX_MASKS) {
-        if (parse_rectangle(optarg,
-                            &blackfilterExclude[blackfilterExcludeCount])) {
-          blackfilterExcludeCount++;
+      if (parse_rectangle(optarg, &tmpRectArg)) {
+        if (!append_mask(&blackfilterExclude, tmpRectArg)) {
+          fprintf(stderr,
+                  "maximum number of blackfilter exclusion (%d) exceeded, "
+                  "ignoring mask %s\n",
+                  MAX_MASKS, optarg);
         }
-      } else {
-        fprintf(stderr,
-                "maximum number of blackfilter exclusion (%d) exceeded, "
-                "ignoring mask %s\n",
-                MAX_MASKS, optarg);
       }
       break;
 
@@ -992,7 +977,7 @@ int main(int argc, char *argv[]) {
       blackfilterScanStep[HORIZONTAL], blackfilterScanStep[VERTICAL],
       blackfilterScanDepth[HORIZONTAL], blackfilterScanDepth[VERTICAL],
       blackfilterScanDirections, blackfilterScanThreshold, blackfilterIntensity,
-      blackfilterExcludeCount, blackfilterExclude);
+      &blackfilterExclude);
   blurfilterParams = validate_blurfilter_parameters(
       blurfilterScanSize[HORIZONTAL], blurfilterScanSize[VERTICAL],
       blurfilterScanStep[HORIZONTAL], blurfilterScanStep[VERTICAL],
@@ -1214,10 +1199,10 @@ int main(int argc, char *argv[]) {
       }
 
       // pre-masking
-      if (preMaskCount > 0) {
+      if (preMasks.count > 0) {
         verboseLog(VERBOSE_NORMAL, "pre-masking\n ");
 
-        apply_masks(sheet, preMasks, preMaskCount, maskColorPixel);
+        apply_masks(sheet, preMasks, maskColorPixel);
       }
 
       // --------------------------------------------------------------
@@ -1250,10 +1235,10 @@ int main(int argc, char *argv[]) {
         if ((preShift[WIDTH] != 0) || ((preShift[HEIGHT] != 0))) {
           printf("pre-shift: [%d,%d]\n", preShift[WIDTH], preShift[HEIGHT]);
         }
-        if (preWipeCount > 0) {
+        if (preWipe.count > 0) {
           printf("pre-wipe: ");
-          for (int i = 0; i < preWipeCount; i++) {
-            print_rectangle(preWipe[i]);
+          for (int i = 0; i < preWipe.count; i++) {
+            print_rectangle(preWipe.masks[i]);
           }
           printf("\n");
         }
@@ -1261,10 +1246,10 @@ int main(int argc, char *argv[]) {
           printf("pre-border: [%d,%d,%d,%d]\n", preBorder.left, preBorder.top,
                  preBorder.right, preBorder.bottom);
         }
-        if (preMaskCount > 0) {
+        if (preMasks.count > 0) {
           printf("pre-masking: ");
-          for (int i = 0; i < preMaskCount; i++) {
-            print_rectangle(preMasks[i]);
+          for (int i = 0; i < preMasks.count; i++) {
+            print_rectangle(preMasks.masks[i]);
           }
           printf("\n");
         }
@@ -1292,10 +1277,10 @@ int main(int argc, char *argv[]) {
           printf("blackfilter-scan-step: [%d,%d]\n", blackfilterScanStep[0],
                  blackfilterScanStep[1]);
           printf("blackfilter-scan-threshold: %f\n", blackfilterScanThreshold);
-          if (blackfilterExcludeCount > 0) {
+          if (blackfilterExclude.count > 0) {
             printf("blackfilter-scan-exclude: ");
-            for (size_t i = 0; i < blackfilterExcludeCount; i++) {
-              print_rectangle(blackfilterExclude[i]);
+            for (size_t i = 0; i < blackfilterExclude.count; i++) {
+              print_rectangle(blackfilterExclude.masks[i]);
             }
             printf("\n");
           }
@@ -1386,10 +1371,10 @@ int main(int argc, char *argv[]) {
           printf("deskew-scan DISABLED for all sheets.\n");
         }
         if (options.no_wipe_multi_index.count != -1) {
-          if (wipeCount > 0) {
+          if (wipe.count > 0) {
             printf("wipe areas: ");
-            for (int i = 0; i < wipeCount; i++) {
-              print_rectangle(wipe[i]);
+            for (size_t i = 0; i < wipe.count; i++) {
+              print_rectangle(wipe.masks[i]);
             }
             printf("\n");
           }
@@ -1427,10 +1412,10 @@ int main(int argc, char *argv[]) {
         } else {
           printf("border-scan DISABLED for all sheets.\n");
         }
-        if (postWipeCount > 0) {
+        if (postWipe.count > 0) {
           printf("post-wipe: ");
-          for (int i = 0; i < postWipeCount; i++) {
-            print_rectangle(postWipe[i]);
+          for (int i = 0; i < postWipe.count; i++) {
+            print_rectangle(postWipe.masks[i]);
           }
           printf("\n");
         }
@@ -1541,13 +1526,14 @@ int main(int argc, char *argv[]) {
           maskScanMaximum[HEIGHT] = sheet.frame->height;
         }
         // avoid inner half of the sheet to be blackfilter-detectable
-        if (blackfilterExcludeCount ==
+        if (blackfilterExclude.count ==
             0) { // no manual settings, use auto-values
           RectangleSize sheetSize = size_of_image(sheet);
-          blackfilterExclude[blackfilterExcludeCount++] = rectangle_from_size(
-              (Point){sheetSize.width / 4, sheetSize.height / 4},
-              (RectangleSize){.width = sheetSize.width / 2,
-                              .height = sheetSize.height / 2});
+          append_mask(&blackfilterExclude,
+                      rectangle_from_size(
+                          (Point){sheetSize.width / 4, sheetSize.height / 4},
+                          (RectangleSize){.width = sheetSize.width / 2,
+                                          .height = sheetSize.height / 2}));
         }
         // set single outside border to start scanning for final border-scan
         if (outsideBorderscanMaskCount ==
@@ -1574,13 +1560,14 @@ int main(int argc, char *argv[]) {
           maskScanMaximum[HEIGHT] = sheet.frame->height;
         }
         if (middleWipe[0] > 0 || middleWipe[1] > 0) { // left, right
-          wipe[wipeCount++] = (Rectangle){{
-              {sheet.frame->width / 2 - middleWipe[0], 0},
-              {sheet.frame->width / 2 + middleWipe[1], sheet.frame->height - 1},
-          }};
+          append_mask(&wipe, (Rectangle){{
+                                 {sheet.frame->width / 2 - middleWipe[0], 0},
+                                 {sheet.frame->width / 2 + middleWipe[1],
+                                  sheet.frame->height - 1},
+                             }});
         }
         // avoid inner half of each page to be blackfilter-detectable
-        if (blackfilterExcludeCount ==
+        if (blackfilterExclude.count ==
             0) { // no manual settings, use auto-values
           RectangleSize sheetSize = size_of_image(sheet);
           RectangleSize filterSize = {
@@ -1591,10 +1578,10 @@ int main(int argc, char *argv[]) {
           Point secondFilterOrigin =
               shift_point(firstFilterOrigin, (Delta){sheet.frame->width / 2});
 
-          blackfilterExclude[blackfilterExcludeCount++] =
-              rectangle_from_size(firstFilterOrigin, filterSize);
-          blackfilterExclude[blackfilterExcludeCount++] =
-              rectangle_from_size(secondFilterOrigin, filterSize);
+          append_mask(&blackfilterExclude,
+                      rectangle_from_size(firstFilterOrigin, filterSize));
+          append_mask(&blackfilterExclude,
+                      rectangle_from_size(secondFilterOrigin, filterSize));
         }
         // set two outside borders to start scanning for final border-scan
         if (outsideBorderscanMaskCount ==
@@ -1619,7 +1606,7 @@ int main(int argc, char *argv[]) {
       // pre-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, preWipe, preWipeCount, maskColorPixel);
+        apply_wipes(sheet, preWipe, maskColorPixel);
       }
 
       // pre-border
@@ -1673,15 +1660,16 @@ int main(int argc, char *argv[]) {
       // mask-detection
       if (!isExcluded(nr, options.no_mask_scan_multi_index,
                       options.ignore_multi_index)) {
-        detect_masks(sheet, maskDetectionParams, points, pointCount, masks);
+        free_mask_array(&masks);
+        masks = detect_masks(sheet, maskDetectionParams, points, pointCount);
       } else {
         verboseLog(VERBOSE_MORE, "+ mask-scan DISABLED for sheet %d\n", nr);
       }
 
       // permanently apply masks
-      if (maskCount > 0) {
+      if (masks.count > 0) {
         saveDebug("_before-masking%d.pnm", nr, sheet);
-        apply_masks(sheet, masks, maskCount, maskColorPixel);
+        apply_masks(sheet, masks, maskColorPixel);
         saveDebug("_after-masking%d.pnm", nr, sheet);
       }
 
@@ -1708,38 +1696,39 @@ int main(int argc, char *argv[]) {
         // masking and grayfilter
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
-          maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, masks);
+          free_mask_array(&masks);
+          masks = detect_masks(sheet, maskDetectionParams, points, pointCount);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before deskewing disabled)\n");
         }
 
         // auto-deskew each mask
-        for (int i = 0; i < maskCount; i++) {
-          saveDebug("_before-deskew-detect%d.pnm", nr * maskCount + i, sheet);
-          float rotation = detect_rotation(sheet, masks[i], deskewParams);
-          saveDebug("_after-deskew-detect%d.pnm", nr * maskCount + i, sheet);
+        for (size_t i = 0; i < masks.count; i++) {
+          saveDebug("_before-deskew-detect%d.pnm", nr * masks.count + i, sheet);
+          float rotation = detect_rotation(sheet, masks.masks[i], deskewParams);
+          saveDebug("_after-deskew-detect%d.pnm", nr * masks.count + i, sheet);
 
           verboseLog(VERBOSE_NORMAL, "rotate (%d,%d): %f\n", points[i].x,
                      points[i].y, rotation);
 
           if (rotation != 0.0) {
             Image rect = create_compatible_image(
-                sheet, size_of_rectangle(masks[i]), false);
+                sheet, size_of_rectangle(masks.masks[i]), false);
             Image rectTarget = create_compatible_image(
-                sheet, size_of_rectangle(masks[i]), true);
+                sheet, size_of_rectangle(masks.masks[i]), true);
 
             // copy area to rotate into rSource
-            copy_rectangle(sheet, rect,
-                           (Rectangle){{masks[i].vertex[0], POINT_INFINITY}},
-                           POINT_ORIGIN);
+            copy_rectangle(
+                sheet, rect,
+                (Rectangle){{masks.masks[i].vertex[0], POINT_INFINITY}},
+                POINT_ORIGIN);
 
             // rotate
             rotate(rect, rectTarget, -rotation, interpolateType);
 
             // copy result back into whole image
             copy_rectangle(rectTarget, sheet, full_image(rectTarget),
-                           masks[i].vertex[0]);
+                           masks.masks[i].vertex[0]);
 
             free_image(&rect);
             free_image(&rectTarget);
@@ -1760,16 +1749,16 @@ int main(int argc, char *argv[]) {
         // perform auto-masking again to get more precise masks after rotation
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
-          maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, masks);
+          free_mask_array(&masks);
+          masks = detect_masks(sheet, maskDetectionParams, points, pointCount);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }
 
         saveDebug("_before-centering%d.pnm", nr, sheet);
         // center masks on the sheet, according to their page position
-        for (int i = 0; i < maskCount; i++) {
-          center_mask(sheet, points[i], masks[i]);
+        for (size_t i = 0; i < masks.count; i++) {
+          center_mask(sheet, points[i], masks.masks[i]);
         }
         saveDebug("_after-centering%d.pnm", nr, sheet);
       } else {
@@ -1780,7 +1769,7 @@ int main(int argc, char *argv[]) {
       // explicit wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, wipe, wipeCount, maskColorPixel);
+        apply_wipes(sheet, wipe, maskColorPixel);
       } else {
         verboseLog(VERBOSE_MORE, "+ wipe DISABLED for sheet %d\n", nr);
       }
@@ -1796,26 +1785,29 @@ int main(int argc, char *argv[]) {
       // border-detection
       if (!isExcluded(nr, options.no_border_scan_multi_index,
                       options.ignore_multi_index)) {
-        Rectangle autoborderMask[outsideBorderscanMaskCount];
+        Masks autoborderMasks = create_mask_array();
         saveDebug("_before-border%d.pnm", nr, sheet);
-        for (int i = 0; i < outsideBorderscanMaskCount; i++) {
-          autoborderMask[i] =
+        for (size_t i = 0; i < outsideBorderscanMaskCount; i++) {
+          // No need to check for result, since the outsideBorderscanMaskCount
+          // is already limited.
+          append_mask(
+              &autoborderMasks,
               border_to_mask(sheet, detect_border(sheet, borderScanParams,
-                                                  outsideBorderscanMask[i]));
+                                                  outsideBorderscanMask[i])));
         }
-        apply_masks(sheet, autoborderMask, outsideBorderscanMaskCount,
-                    maskColorPixel);
+        apply_masks(sheet, autoborderMasks, maskColorPixel);
         for (int i = 0; i < outsideBorderscanMaskCount; i++) {
           // border-centering
           if (!isExcluded(nr, options.no_border_align_multi_index,
                           options.ignore_multi_index)) {
-            align_mask(sheet, autoborderMask[i], outsideBorderscanMask[i],
-                       maskAlignmentParams);
+            align_mask(sheet, autoborderMasks.masks[i],
+                       outsideBorderscanMask[i], maskAlignmentParams);
           } else {
             verboseLog(VERBOSE_MORE,
                        "+ border-centering DISABLED for sheet %d\n", nr);
           }
         }
+        free_mask_array(&autoborderMasks);
         saveDebug("_after-border%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ border-scan DISABLED for sheet %d\n", nr);
@@ -1824,7 +1816,7 @@ int main(int argc, char *argv[]) {
       // post-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, postWipe, postWipeCount, maskColorPixel);
+        apply_wipes(sheet, postWipe, maskColorPixel);
       }
 
       // post-border

--- a/unpaper.h
+++ b/unpaper.h
@@ -28,11 +28,9 @@
 void loadImage(const char *filename, Image *image, Pixel sheet_background,
                uint8_t abs_black_threshold);
 
-void saveImage(char *filename, Image image, int outputPixFmt,
-               Pixel sheet_background, uint8_t abs_black_threshold);
+void saveImage(char *filename, Image image, int outputPixFmt);
 
-void saveDebug(char *filenameTemplate, int index, Image image,
-               Pixel sheet_background, uint8_t abs_black_threshold)
+void saveDebug(char *filenameTemplate, int index, Image image)
     __attribute__((format(printf, 1, 0)));
 
 /* --- arithmetic tool functions ------------------------------------------ */

--- a/unpaper.h
+++ b/unpaper.h
@@ -42,19 +42,3 @@ static inline void limit(int *i, int max) {
     *i = max;
   }
 }
-
-#define red(pixel) ((pixel >> 16) & 0xff)
-#define green(pixel) ((pixel >> 8) & 0xff)
-#define blue(pixel) (pixel & 0xff)
-
-static inline int pixelValue(uint8_t r, uint8_t g, uint8_t b) {
-  return (r) << 16 | (g) << 8 | (b);
-}
-
-static inline Pixel pixelValueToPixel(uint32_t pixelValue) {
-  return (Pixel){
-      .r = (pixelValue >> 16) & 0xff,
-      .g = (pixelValue >> 8) & 0xff,
-      .b = pixelValue & 0xff,
-  };
-}

--- a/unpaper.h
+++ b/unpaper.h
@@ -25,13 +25,13 @@
 
 /* --- tool function for file handling ------------------------------------ */
 
-void loadImage(const char *filename, AVFrame **image, Pixel sheet_background,
+void loadImage(const char *filename, Image *image, Pixel sheet_background,
                uint8_t abs_black_threshold);
 
-void saveImage(char *filename, AVFrame *image, int outputPixFmt,
+void saveImage(char *filename, Image image, int outputPixFmt,
                Pixel sheet_background, uint8_t abs_black_threshold);
 
-void saveDebug(char *filenameTemplate, int index, AVFrame *image,
+void saveDebug(char *filenameTemplate, int index, Image image,
                Pixel sheet_background, uint8_t abs_black_threshold)
     __attribute__((format(printf, 1, 0)));
 


### PR DESCRIPTION
Make masks handling use dedicated structures.

This is worth benchmarking, because it will definitely cause more
allocations, but it would avoid allocating multiple kilobytes of stack
for the masks that are only appended to once or twice.
