### PR TITLE
Use per-format callbacks as part of the image get/set pixel.

### DIFF
--- a/file.c
+++ b/file.c
@@ -113,8 +113,8 @@ void loadImage(const char *filename, Image *image, Pixel sheet_background,
     const uint32_t *palette = (const uint32_t *)frame->data[1];
     scan_rectangle(area) {
       const uint8_t palette_index = frame->data[0][frame->linesize[0] * y + x];
-      set_pixel(*image, (Point){x, y}, pixel_from_value(palette[palette_index]),
-                abs_black_threshold);
+      set_pixel(*image, (Point){x, y},
+                pixel_from_value(palette[palette_index]));
     }
   } break;
 
@@ -134,8 +134,7 @@ void loadImage(const char *filename, Image *image, Pixel sheet_background,
  * @param type filetype of the image to save
  * @return true on success, false on failure
  */
-void saveImage(char *filename, Image input, int outputPixFmt,
-               Pixel sheet_background, uint8_t abs_black_threshold) {
+void saveImage(char *filename, Image input, int outputPixFmt) {
   enum AVCodecID output_codec = -1;
   const AVCodec *codec;
   AVFormatContext *out_ctx;
@@ -177,9 +176,8 @@ void saveImage(char *filename, Image input, int outputPixFmt,
 
   if (input.frame->format != outputPixFmt) {
     output = create_image(size_of_image(input), outputPixFmt, false,
-                          sheet_background, abs_black_threshold);
-    copy_rectangle(input, output, full_image(input), POINT_ORIGIN,
-                   abs_black_threshold);
+                          input.background, input.abs_black_threshold);
+    copy_rectangle(input, output, full_image(input), POINT_ORIGIN);
   }
 
   codec = avcodec_find_encoder(output_codec);
@@ -258,12 +256,10 @@ void saveImage(char *filename, Image input, int outputPixFmt,
 /**
  * Saves the image if full debugging mode is enabled.
  */
-void saveDebug(char *filenameTemplate, int index, Image image,
-               Pixel sheet_background, uint8_t abs_black_threshold) {
+void saveDebug(char *filenameTemplate, int index, Image image) {
   if (verbose >= VERBOSE_DEBUG_SAVE) {
     char debugFilename[100];
     sprintf(debugFilename, filenameTemplate, index);
-    saveImage(debugFilename, image, image.frame->format, sheet_background,
-              abs_black_threshold);
+    saveImage(debugFilename, image, image.frame->format);
   }
 }

--- a/file.c
+++ b/file.c
@@ -90,20 +90,23 @@ void loadImage(const char *filename, Image *image, Pixel sheet_background,
     errOutput("error while receiving frame from decoder: %s", errbuff);
   }
 
+  Rectangle area = rectangle_from_size(
+      POINT_ORIGIN,
+      (RectangleSize){.width = frame->width, .height = frame->height});
+
   switch (frame->format) {
   case AV_PIX_FMT_Y400A: // 8-bit grayscale PNG
   case AV_PIX_FMT_GRAY8:
   case AV_PIX_FMT_RGB24:
   case AV_PIX_FMT_MONOBLACK:
   case AV_PIX_FMT_MONOWHITE:
+    *image = create_image(size_of_rectangle(area), frame->format, false,
+                          sheet_background, abs_black_threshold);
+    av_frame_free(&image->frame);
     image->frame = av_frame_clone(frame);
     break;
 
   case AV_PIX_FMT_PAL8: {
-    Rectangle area = rectangle_from_size(
-        POINT_ORIGIN,
-        (RectangleSize){.width = frame->width, .height = frame->height});
-
     *image = create_image(size_of_rectangle(area), AV_PIX_FMT_RGB24, false,
                           sheet_background, abs_black_threshold);
 

--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -189,8 +189,7 @@ void stretch_and_replace(Image *pImage, RectangleSize size,
   if (compare_sizes(size_of_image(*pImage), size) == 0)
     return;
 
-  Image target = create_image(size, pImage->frame->format, false, PIXEL_WHITE,
-                              abs_black_threshold);
+  Image target = create_compatible_image(*pImage, size, false);
 
   stretch_frame(*pImage, target, interpolate_type, abs_black_threshold);
   replace_image(pImage, &target);
@@ -233,8 +232,7 @@ void resize_and_replace(Image *pImage, RectangleSize size,
     return;
   }
 
-  Image resized = create_image(size, pImage->frame->format, true,
-                               sheet_background, abs_black_threshold);
+  Image resized = create_compatible_image(*pImage, size, true);
   center_image(*pImage, resized, POINT_ORIGIN, size, sheet_background,
                abs_black_threshold);
   replace_image(pImage, &resized);
@@ -245,9 +243,10 @@ void flip_rotate_90(Image *pImage, RotationDirection direction,
   RectangleSize image_size = size_of_image(*pImage);
 
   // exchanged width and height
-  Image newimage = create_image(
+  Image newimage = create_compatible_image(
+      *pImage,
       (RectangleSize){.width = image_size.height, .height = image_size.width},
-      pImage->frame->format, false, PIXEL_WHITE, abs_black_threshold);
+      false);
 
   for (int y = 0; y < image_size.height; y++) {
     const int xx =
@@ -306,8 +305,8 @@ void mirror(Image image, bool horizontal, bool vertical,
 void shift_image(Image *pImage, Delta d, Pixel sheet_background,
                  uint8_t abs_black_threshold) {
   // allocate new buffer's memory
-  Image newimage = create_image(size_of_image(*pImage), pImage->frame->format,
-                                true, sheet_background, abs_black_threshold);
+  Image newimage =
+      create_compatible_image(*pImage, size_of_image(*pImage), true);
 
   copy_rectangle(*pImage, newimage, full_image(*pImage),
                  shift_point(POINT_ORIGIN, d), abs_black_threshold);

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -10,42 +10,34 @@
 #include "imageprocess/interpolate.h"
 #include "imageprocess/primitives.h"
 
-uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color,
-                        uint8_t abs_black_threshold);
+uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color);
 void copy_rectangle(Image source, Image target, Rectangle source_area,
-                    Point target_coords, uint8_t abs_black_threshold);
+                    Point target_coords);
 uint8_t inverse_brightness_rect(Image image, Rectangle input_area);
 uint8_t inverse_lightness_rect(Image image, Rectangle input_area);
 uint8_t darkness_rect(Image image, Rectangle input_area);
 uint64_t count_pixels_within_brightness(Image image, Rectangle area,
                                         uint8_t min_brightness,
-                                        uint8_t max_brightness, bool clear,
-                                        uint8_t abs_black_threshold);
+                                        uint8_t max_brightness, bool clear);
 
 typedef int8_t RotationDirection;
 static const RotationDirection ROTATE_CLOCKWISE = 1;
 static const RotationDirection ROTATE_ANTICLOCKWISE = -1;
 
 void center_image(Image source, Image target, Point target_origin,
-                  RectangleSize target_size, Pixel sheet_background,
-                  uint8_t abs_black_threshold);
+                  RectangleSize target_size);
 
 void stretch_and_replace(Image *pImage, RectangleSize size,
-                         Interpolation interpolate_type,
-                         uint8_t abs_black_threshold);
+                         Interpolation interpolate_type);
 
 void resize_and_replace(Image *pImage, RectangleSize size,
-                        Interpolation interpolate_type, Pixel sheet_background,
-                        uint8_t abs_black_threshold);
+                        Interpolation interpolate_type);
 
 // Rotates an image clockwise or anti-clockwise in 90-degrees.
-void flip_rotate_90(Image *pImage, RotationDirection direction,
-                    uint8_t abs_black_threshold);
+void flip_rotate_90(Image *pImage, RotationDirection direction);
 
 // Mirrors an image either horizontally, vertically, or both.
-void mirror(Image image, bool horizontal, bool vertical,
-            uint8_t abs_black_threshold);
+void mirror(Image image, bool horizontal, bool vertical);
 
 // Shifts the image.
-void shift_image(Image *pImage, Delta d, Pixel sheet_background,
-                 uint8_t abs_black_threshold);
+void shift_image(Image *pImage, Delta d);

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -4,6 +4,8 @@
 
 #include <math.h>
 
+#include <libavutil/mathematics.h> // for M_PI
+
 #include "constants.h"
 #include "imageprocess/deskew.h"
 #include "imageprocess/interpolate.h"

--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -245,7 +245,7 @@ float detect_rotation(Image image, const Rectangle mask,
  * rotate, and re-paste with copyBuffer.)
  */
 void rotate(Image source, Image target, const float radians,
-            uint8_t abs_black_threshold, Interpolation interpolate_type) {
+            Interpolation interpolate_type) {
   Rectangle source_area = full_image(source);
   RectangleSize source_size = size_of_image(source);
 
@@ -260,6 +260,6 @@ void rotate(Image source, Image target, const float radians,
     const float srcY = midY + (y - midY) * cosval - (x - midX) * sinval;
     const Pixel pxl =
         interpolate(source, (FloatPoint){srcX, srcY}, interpolate_type);
-    set_pixel(target, (Point){x, y}, pxl, abs_black_threshold);
+    set_pixel(target, (Point){x, y}, pxl);
   }
 }

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -31,4 +31,4 @@ float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);
 
 void rotate(Image source, Image target, const float radians,
-            uint8_t abs_black_threshold, Interpolation interpolate_type);
+            Interpolation interpolate_type);

--- a/imageprocess/fill.c
+++ b/imageprocess/fill.c
@@ -15,7 +15,7 @@
  */
 static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
                           uint8_t mask_min, uint8_t mask_max,
-                          uint64_t intensity, uint8_t abs_black_threshold) {
+                          uint64_t intensity) {
   uint64_t distance = 0;
   uint64_t intensityCount =
       1; // first pixel must match, otherwise directly exit
@@ -37,7 +37,7 @@ static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
       return distance;
     }
 
-    set_pixel(image, p, color, abs_black_threshold);
+    set_pixel(image, p, color);
     distance++;
   }
 }
@@ -54,22 +54,21 @@ static uint64_t fill_line(Image image, Point p, Delta step, Pixel color,
 static void flood_fill_around_line(Image image, Point p, Delta step,
                                    uint64_t distance, Pixel color,
                                    uint8_t mask_min, uint8_t mask_max,
-                                   uint64_t intensity,
-                                   uint8_t abs_black_threshold) {
+                                   uint64_t intensity) {
   for (uint64_t d = 0; d < distance; d++) {
     if (step.horizontal != 0) {
       p.x += step.horizontal;
       // indirect recursion
       flood_fill(image, shift_point(p, DELTA_DOWNWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
       flood_fill(image, shift_point(p, DELTA_UPWARD), color, mask_min, mask_max,
-                 intensity, abs_black_threshold);
+                 intensity);
     } else { // step.vertical != 0
       p.y += step.vertical;
       flood_fill(image, shift_point(p, DELTA_RIGHTWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
       flood_fill(image, shift_point(p, DELTA_LEFTWARD), color, mask_min,
-                 mask_max, intensity, abs_black_threshold);
+                 mask_max, intensity);
     }
   }
 }
@@ -80,30 +79,29 @@ static void flood_fill_around_line(Image image, Point p, Delta step,
  * @see earlier header-declaration to enable indirect recursive calls
  */
 void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
-                uint8_t mask_max, uint64_t intensity,
-                uint8_t abs_black_threshold) {
+                uint8_t mask_max, uint64_t intensity) {
   // is current pixel to be filled?
   uint8_t pixel = get_pixel_grayscale(image, p);
   if ((pixel >= mask_min) && (pixel <= mask_max)) {
     // first, fill a 'cross' (both vertical, horizontal line)
-    set_pixel(image, p, color, abs_black_threshold);
+    set_pixel(image, p, color);
     const uint64_t left = fill_line(image, p, DELTA_LEFTWARD, color, mask_min,
-                                    mask_max, intensity, abs_black_threshold);
-    const uint64_t top = fill_line(image, p, DELTA_UPWARD, color, mask_min,
-                                   mask_max, intensity, abs_black_threshold);
+                                    mask_max, intensity);
+    const uint64_t top =
+        fill_line(image, p, DELTA_UPWARD, color, mask_min, mask_max, intensity);
     const uint64_t right = fill_line(image, p, DELTA_RIGHTWARD, color, mask_min,
-                                     mask_max, intensity, abs_black_threshold);
+                                     mask_max, intensity);
     const uint64_t bottom = fill_line(image, p, DELTA_DOWNWARD, color, mask_min,
-                                      mask_max, intensity, abs_black_threshold);
+                                      mask_max, intensity);
     // now recurse on each neighborhood-pixel of the cross (most recursions will
     // immediately return)
     flood_fill_around_line(image, p, DELTA_LEFTWARD, left, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_UPWARD, top, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_RIGHTWARD, right, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
     flood_fill_around_line(image, p, DELTA_DOWNWARD, bottom, color, mask_min,
-                           mask_max, intensity, abs_black_threshold);
+                           mask_max, intensity);
   }
 }

--- a/imageprocess/fill.h
+++ b/imageprocess/fill.h
@@ -10,5 +10,4 @@
 #include "imageprocess/primitives.h"
 
 void flood_fill(Image image, Point p, Pixel color, uint8_t mask_min,
-                uint8_t mask_max, uint64_t intensity,
-                uint8_t abs_black_threshold);
+                uint8_t mask_max, uint64_t intensity);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 
 #include "constants.h"

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -32,8 +32,7 @@ typedef struct {
   Rectangle *exclusions;
 } BlackfilterParameters;
 
-void blackfilter(Image image, BlackfilterParameters params,
-                 uint8_t abs_black_threshold);
+void blackfilter(Image image, BlackfilterParameters params);
 
 BlackfilterParameters validate_blackfilter_parameters(
     uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
@@ -59,10 +58,9 @@ BlurfilterParameters validate_blurfilter_parameters(uint32_t scan_size_h,
                                                     float intensity);
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
-                    uint8_t abs_white_threshold, uint8_t abs_black_threshold);
+                    uint8_t abs_white_threshold);
 
-uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level,
-                     uint8_t abs_black_threshold);
+uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level);
 
 typedef struct {
   RectangleSize scan_size;
@@ -81,5 +79,4 @@ GrayfilterParameters validate_grayfilter_parameters(uint32_t scan_size_h,
                                                     uint32_t scan_step_v,
                                                     float threshold);
 
-uint64_t grayfilter(Image image, GrayfilterParameters params,
-                    uint8_t abs_black_threshold);
+uint64_t grayfilter(Image image, GrayfilterParameters params);

--- a/imageprocess/image.c
+++ b/imageprocess/image.c
@@ -34,8 +34,7 @@ Image create_image(RectangleSize size, int pixel_format, bool fill,
   }
 
   if (fill) {
-    wipe_rectangle(image, full_image(image), sheet_background,
-                   abs_black_threshold);
+    wipe_rectangle(image, full_image(image), image.background);
   }
 
   return image;

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -8,14 +8,22 @@
 
 typedef struct AVFrame AVFrame;
 
-typedef struct {
+typedef struct Image Image;
+
+typedef Pixel (*get_pixel_cb)(struct Image image, Point coords);
+typedef void (*set_pixel_cb)(struct Image image, Point coords, Pixel pixel);
+
+typedef struct Image {
   AVFrame *frame;
   Pixel background;
   uint8_t abs_black_threshold;
+
+  get_pixel_cb _get_pixel;
+  set_pixel_cb _set_pixel;
 } Image;
 
 #define EMPTY_IMAGE                                                            \
-  (Image) { NULL, PIXEL_WHITE, 0 }
+  (Image) { .frame = NULL }
 
 Image create_image(RectangleSize size, int pixel_format, bool fill,
                    Pixel sheet_background, uint8_t abs_black_threshold);

--- a/imageprocess/image.h
+++ b/imageprocess/image.h
@@ -21,6 +21,7 @@ Image create_image(RectangleSize size, int pixel_format, bool fill,
                    Pixel sheet_background, uint8_t abs_black_threshold);
 void replace_image(Image *image, Image *new_image);
 void free_image(Image *image);
+Image create_compatible_image(Image source, RectangleSize size, bool fill);
 
 RectangleSize size_of_image(Image image);
 Rectangle full_image(Image image);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/masks.h"
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "imageprocess/blit.h"
+#include "imageprocess/masks.h"
 #include "imageprocess/pixel.h"
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
@@ -231,8 +235,7 @@ void center_mask(Image image, const Point center, const Rectangle area,
                area.vertex[0].x, area.vertex[0].y, area.vertex[1].x,
                area.vertex[1].y, center.x, center.y,
                target.x - area.vertex[0].x, target.y - area.vertex[0].y);
-    Image newimage = create_image(size, image.frame->format, false, PIXEL_WHITE,
-                                  abs_black_threshold);
+    Image newimage = create_compatible_image(image, size, false);
     copy_rectangle(image, newimage, area, POINT_ORIGIN, abs_black_threshold);
     wipe_rectangle(image, area, sheet_background, abs_black_threshold);
     copy_rectangle(newimage, image, full_image(newimage), target,
@@ -302,8 +305,7 @@ void align_mask(Image image, const Rectangle inside_area,
              target.y, target.x - inside_area.vertex[0].x,
              target.y - inside_area.vertex[0].y);
 
-  Image newimage = create_image(inside_size, image.frame->format, true,
-                                sheet_background, abs_black_threshold);
+  Image newimage = create_compatible_image(image, inside_size, true);
   copy_rectangle(image, newimage, inside_area, POINT_ORIGIN,
                  abs_black_threshold);
   wipe_rectangle(image, inside_area, sheet_background, abs_black_threshold);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -188,14 +188,14 @@ static const Rectangle INVALID_MASK = {{{-1, -1}, {-1, -1}}};
  */
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]) {
+                    Rectangle masks[]) {
   size_t masks_count = 0;
   if (!params.scan_horizontal && !params.scan_vertical) {
     return masks_count;
   }
 
   for (size_t i = 0; i < points_count; i++) {
-    mask_valid[i] = detect_mask(image, params, points[i], &masks[i]);
+    bool mask_valid = detect_mask(image, params, points[i], &masks[i]);
 
     // Compare the newly-detected mask with an invalid mask where all the
     // vertex are (-1, -1)
@@ -206,7 +206,7 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
           VERBOSE_NORMAL, "auto-masking (%d,%d): %d,%d,%d,%d%s\n", points[i].x,
           points[i].y, masks[i].vertex[0].x, masks[i].vertex[0].y,
           masks[i].vertex[1].x, masks[i].vertex[1].y,
-          mask_valid[i] ? "" : " (invalid detection, using full page size)");
+          mask_valid ? "" : " (invalid detection, using full page size)");
     } else {
       verboseLog(VERBOSE_NORMAL, "auto-masking (%d,%d): NO MASK FOUND\n",
                  points[i].x, points[i].y);

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -52,8 +52,7 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
                     bool mask_valid[], Rectangle masks[]);
 
-void center_mask(Image image, const Point center, const Rectangle area,
-                 Pixel sheet_background, uint8_t abs_black_threshold);
+void center_mask(Image image, const Point center, const Rectangle area);
 
 typedef struct {
   struct {
@@ -74,14 +73,13 @@ validate_mask_alignment_parameters(int border_align,
                                    const int margin[DIRECTIONS_COUNT]);
 
 void align_mask(Image image, const Rectangle inside_area,
-                const Rectangle outside, MaskAlignmentParameters params,
-                Pixel sheet_background, uint8_t abs_black_threshold);
+                const Rectangle outside, MaskAlignmentParameters params);
 
 void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
-                 Pixel color, uint8_t abs_black_threshold);
+                 Pixel color);
 
 void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
-                 Pixel color, uint8_t abs_black_threshold);
+                 Pixel color);
 
 typedef struct {
   int32_t left;
@@ -93,8 +91,7 @@ typedef struct {
 static const Border BORDER_NULL = {0, 0, 0, 0};
 
 Rectangle border_to_mask(Image image, const Border border);
-void apply_border(Image image, const Border border, Pixel color,
-                  uint8_t abs_black_threshold);
+void apply_border(Image image, const Border border, Pixel color);
 
 typedef struct {
   RectangleSize scan_size;
@@ -120,4 +117,4 @@ validate_border_scan_parameters(int scan_directions,
                                 const int scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,
-                     const Rectangle outside_mask, uint8_t abs_black_threshold);
+                     const Rectangle outside_mask);

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -50,7 +50,7 @@ validate_mask_detection_parameters(int scan_directions,
 
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
-                    bool mask_valid[], Rectangle masks[]);
+                    Rectangle masks[]);
 
 void center_mask(Image image, const Point center, const Rectangle area);
 

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -147,8 +147,7 @@ uint8_t get_pixel_darkness_inverse(Image image, Point coords) {
  * @return true if the pixel has been changed, false if the original color was
  * the one to set
  */
-bool set_pixel(Image image, Point coords, Pixel pixel,
-               uint8_t abs_black_threshold) {
+bool set_pixel(Image image, Point coords, Pixel pixel) {
   uint8_t *pix;
 
   if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
@@ -156,7 +155,7 @@ bool set_pixel(Image image, Point coords, Pixel pixel,
     return false; // nop
   }
 
-  uint8_t pixelbw = pixel_grayscale(pixel) < abs_black_threshold
+  uint8_t pixelbw = pixel_grayscale(pixel) < image.abs_black_threshold
                         ? BLACK_COMPONENT
                         : WHITE_COMPONENT;
 

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -17,58 +17,17 @@ void errOutput(const char *fmt, ...);
 #define WHITE_COMPONENT 0xFF
 #define BLACK_COMPONENT 0x00
 
-static inline uint8_t pixel_grayscale(Pixel pixel) {
+uint8_t pixel_grayscale(Pixel pixel) {
   return (pixel.r + pixel.g + pixel.b) / 3;
 }
 
 static Pixel get_pixel_components(Image image, Point coords, uint8_t defval) {
-  Pixel pixel = {defval, defval, defval};
-  uint8_t *pix;
-
   if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
       (coords.y >= image.frame->height)) {
-    return pixel;
+    return (Pixel){defval, defval, defval};
   }
 
-  switch (image.frame->format) {
-  case AV_PIX_FMT_GRAY8:
-    pix =
-        image.frame->data[0] + (coords.y * image.frame->linesize[0] + coords.x);
-    pixel.r = pixel.g = pixel.b = *pix;
-    break;
-  case AV_PIX_FMT_Y400A:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x * 2);
-    pixel.r = pixel.g = pixel.b = *pix;
-    break;
-  case AV_PIX_FMT_RGB24:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x * 3);
-    pixel.r = pix[0];
-    pixel.g = pix[1];
-    pixel.b = pix[2];
-    break;
-  case AV_PIX_FMT_MONOWHITE:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x / 8);
-    if (*pix & (128 >> (coords.x % 8)))
-      pixel.r = pixel.g = pixel.b = BLACK_COMPONENT;
-    else
-      pixel.r = pixel.g = pixel.b = WHITE_COMPONENT;
-    break;
-  case AV_PIX_FMT_MONOBLACK:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x / 8);
-    if (*pix & (128 >> (coords.x % 8)))
-      pixel.r = pixel.g = pixel.b = WHITE_COMPONENT;
-    else
-      pixel.r = pixel.g = pixel.b = BLACK_COMPONENT;
-    break;
-  default:
-    errOutput("unknown pixel format.");
-  }
-
-  return pixel;
+  return image._get_pixel(image, coords);
 }
 
 Pixel pixel_from_value(uint32_t value) {
@@ -148,49 +107,12 @@ uint8_t get_pixel_darkness_inverse(Image image, Point coords) {
  * the one to set
  */
 bool set_pixel(Image image, Point coords, Pixel pixel) {
-  uint8_t *pix;
-
   if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
       (coords.y >= image.frame->height)) {
     return false; // nop
   }
 
-  uint8_t pixelbw = pixel_grayscale(pixel) < image.abs_black_threshold
-                        ? BLACK_COMPONENT
-                        : WHITE_COMPONENT;
+  image._set_pixel(image, coords, pixel);
 
-  switch (image.frame->format) {
-  case AV_PIX_FMT_GRAY8:
-    pix =
-        image.frame->data[0] + (coords.y * image.frame->linesize[0] + coords.x);
-    *pix = pixel_grayscale(pixel);
-    break;
-  case AV_PIX_FMT_Y400A:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x * 2);
-    pix[0] = pixel_grayscale(pixel);
-    pix[1] = 0xFF; // no alpha.
-    break;
-  case AV_PIX_FMT_RGB24:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x * 3);
-    pix[0] = pixel.r;
-    pix[1] = pixel.g;
-    pix[2] = pixel.b;
-    break;
-  case AV_PIX_FMT_MONOWHITE:
-    pixelbw = ~pixelbw; // reverse compared to following case
-  case AV_PIX_FMT_MONOBLACK:
-    pix = image.frame->data[0] +
-          (coords.y * image.frame->linesize[0] + coords.x / 8);
-    if (pixelbw == WHITE_COMPONENT) {
-      *pix = *pix | (128 >> (coords.x % 8));
-    } else if (pixelbw == BLACK_COMPONENT) {
-      *pix = *pix & ~(128 >> (coords.x % 8));
-    }
-    break;
-  default:
-    errOutput("unknown pixel format.");
-  }
   return true;
 }

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -16,5 +16,4 @@ Pixel get_pixel(Image image, Point coords);
 uint8_t get_pixel_grayscale(Image image, Point coords);
 uint8_t get_pixel_lightness(Image image, Point coords);
 uint8_t get_pixel_darkness_inverse(Image image, Point coords);
-bool set_pixel(Image image, Point coords, Pixel pixel,
-               uint8_t abs_black_threshold);
+bool set_pixel(Image image, Point coords, Pixel pixel);

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -10,6 +10,7 @@
 #include "imageprocess/image.h"
 #include "imageprocess/primitives.h"
 
+uint8_t pixel_grayscale(Pixel pixel);
 Pixel pixel_from_value(uint32_t value);
 int compare_pixel(Pixel a, Pixel b);
 Pixel get_pixel(Image image, Point coords);

--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -4,8 +4,10 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
-#include "imageprocess/primitives.h"
+#include <stdlib.h>
+
 #include "imageprocess/math_util.h"
+#include "imageprocess/primitives.h"
 
 Delta distance_between(Point a, Point b) {
   return (Delta){

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <libavutil/frame.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {

--- a/lib/options.c
+++ b/lib/options.c
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/unpaper.c
+++ b/unpaper.c
@@ -234,7 +234,6 @@ int main(int argc, char *argv[]) {
   Border preBorder = {0, 0, 0, 0};
   Border postBorder = {0, 0, 0, 0};
   Border border = {0, 0, 0, 0};
-  bool maskValid[MAX_MASKS];
   float whiteThreshold = 0.9;
   float blackThreshold = 0.33;
   bool writeoutput = true;
@@ -579,7 +578,6 @@ int main(int argc, char *argv[]) {
     case 'm':
       if (maskCount < MAX_MASKS) {
         if (parse_rectangle(optarg, &masks[maskCount])) {
-          maskValid[maskCount] = true;
           maskCount++;
         }
       } else {
@@ -1675,8 +1673,7 @@ int main(int argc, char *argv[]) {
       // mask-detection
       if (!isExcluded(nr, options.no_mask_scan_multi_index,
                       options.ignore_multi_index)) {
-        detect_masks(sheet, maskDetectionParams, points, pointCount, maskValid,
-                     masks);
+        detect_masks(sheet, maskDetectionParams, points, pointCount, masks);
       } else {
         verboseLog(VERBOSE_MORE, "+ mask-scan DISABLED for sheet %d\n", nr);
       }
@@ -1712,7 +1709,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before deskewing disabled)\n");
         }
@@ -1764,7 +1761,7 @@ int main(int argc, char *argv[]) {
         if (!isExcluded(nr, options.no_mask_scan_multi_index,
                         options.ignore_multi_index)) {
           maskCount = detect_masks(sheet, maskDetectionParams, points,
-                                   pointCount, maskValid, masks);
+                                   pointCount, masks);
         } else {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }

--- a/unpaper.c
+++ b/unpaper.c
@@ -1755,12 +1755,10 @@ int main(int argc, char *argv[]) {
                      points[i].y, rotation);
 
           if (rotation != 0.0) {
-            Image rect =
-                create_image(size_of_rectangle(masks[i]), sheet.frame->format,
-                             false, sheetBackgroundPixel, absBlackThreshold);
-            Image rectTarget =
-                create_image(size_of_image(rect), sheet.frame->format, true,
-                             sheetBackgroundPixel, absBlackThreshold);
+            Image rect = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), false);
+            Image rectTarget = create_compatible_image(
+                sheet, size_of_rectangle(masks[i]), true);
 
             // copy area to rotate into rSource
             copy_rectangle(sheet, rect,
@@ -1949,11 +1947,11 @@ int main(int argc, char *argv[]) {
 
         for (int j = 0; j < options.output_count; j++) {
           // get pagebuffer
-          page = create_image(
+          page = create_compatible_image(
+              sheet,
               (RectangleSize){sheet.frame->width / options.output_count,
                               sheet.frame->height},
-              sheet.frame->format, false, sheetBackgroundPixel,
-              absBlackThreshold);
+              false);
           copy_rectangle(
               sheet, page,
               (Rectangle){{{page.frame->width * j, 0},

--- a/unpaper.c
+++ b/unpaper.c
@@ -1124,8 +1124,7 @@ int main(int argc, char *argv[]) {
 
           loadImage(inputFileNames[j], &page, sheetBackgroundPixel,
                     absBlackThreshold);
-          saveDebug("_loaded_%d.pnm", inputNr - options.input_count + j, page,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_loaded_%d.pnm", inputNr - options.input_count + j, page);
 
           if (outputPixFmt == -1 && page.frame != NULL) {
             outputPixFmt = page.frame->format;
@@ -1135,7 +1134,7 @@ int main(int argc, char *argv[]) {
           if (preRotate != 0) {
             verboseLog(VERBOSE_NORMAL, "pre-rotating %d degrees.\n", preRotate);
 
-            flip_rotate_90(&page, preRotate / 90, absBlackThreshold);
+            flip_rotate_90(&page, preRotate / 90);
           }
 
           // if sheet-size is not known yet (and not forced by --sheet-size),
@@ -1165,19 +1164,15 @@ int main(int argc, char *argv[]) {
                                sheetBackgroundPixel, absBlackThreshold);
         }
         if (page.frame != NULL) {
-          saveDebug("_page%d.pnm", inputNr - options.input_count + j, page,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_page%d.pnm", inputNr - options.input_count + j, page);
           saveDebug("_before_center_page%d.pnm",
-                    inputNr - options.input_count + j, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+                    inputNr - options.input_count + j, sheet);
 
           center_image(page, sheet, (Point){(w * j / options.input_count), 0},
-                       (RectangleSize){(w / options.input_count), h},
-                       sheetBackgroundPixel, absBlackThreshold);
+                       (RectangleSize){(w / options.input_count), h});
 
           saveDebug("_after_center_page%d.pnm",
-                    inputNr - options.input_count + j, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+                    inputNr - options.input_count + j, sheet);
         }
       }
 
@@ -1209,7 +1204,7 @@ int main(int argc, char *argv[]) {
                    getDirections(preMirror));
 
         mirror(sheet, !!(preMirror & (1 << HORIZONTAL)),
-               !!(preMirror & (1 << VERTICAL)), absBlackThreshold);
+               !!(preMirror & (1 << VERTICAL)));
       }
 
       // pre-shifting
@@ -1217,16 +1212,14 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "pre-shifting [%d,%d]\n", preShift[WIDTH],
                    preShift[HEIGHT]);
 
-        shift_image(&sheet, (Delta){preShift[WIDTH], preShift[HEIGHT]},
-                    sheetBackgroundPixel, absBlackThreshold);
+        shift_image(&sheet, (Delta){preShift[WIDTH], preShift[HEIGHT]});
       }
 
       // pre-masking
       if (preMaskCount > 0) {
         verboseLog(VERBOSE_NORMAL, "pre-masking\n ");
 
-        apply_masks(sheet, preMasks, preMaskCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_masks(sheet, preMasks, preMaskCount, maskColorPixel);
       }
 
       // --------------------------------------------------------------
@@ -1513,12 +1506,9 @@ int main(int argc, char *argv[]) {
       w *= zoomFactor;
       h *= zoomFactor;
 
-      saveDebug("_before-stretch%d.pnm", nr, sheet, sheetBackgroundPixel,
-                absBlackThreshold);
-      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                          absBlackThreshold);
-      saveDebug("_after-stretch%d.pnm", nr, sheet, sheetBackgroundPixel,
-                absBlackThreshold);
+      saveDebug("_before-stretch%d.pnm", nr, sheet);
+      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
+      saveDebug("_after-stretch%d.pnm", nr, sheet);
 
       // size
       if ((size[WIDTH] != -1) || (size[HEIGHT] != -1)) {
@@ -1532,12 +1522,9 @@ int main(int argc, char *argv[]) {
         } else {
           h = sheet.frame->height;
         }
-        saveDebug("_before-resize%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                           sheetBackgroundPixel, absBlackThreshold);
-        saveDebug("_after-resize%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-resize%d.pnm", nr, sheet);
+        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
+        saveDebug("_after-resize%d.pnm", nr, sheet);
       }
 
       // handle sheet layout
@@ -1634,24 +1621,21 @@ int main(int argc, char *argv[]) {
       // pre-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, preWipe, preWipeCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_wipes(sheet, preWipe, preWipeCount, maskColorPixel);
       }
 
       // pre-border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, preBorder, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, preBorder, maskColorPixel);
       }
 
       // black area filter
       if (!isExcluded(nr, options.no_blackfilter_multi_index,
                       options.ignore_multi_index)) {
-        saveDebug("_before-blackfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        blackfilter(sheet, blackfilterParams, absBlackThreshold);
-        saveDebug("_after-blackfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-blackfilter%d.pnm", nr, sheet);
+        blackfilter(sheet, blackfilterParams);
+        saveDebug("_after-blackfilter%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ blackfilter DISABLED for sheet %d\n", nr);
       }
@@ -1661,12 +1645,10 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "noise-filter ...");
 
-        saveDebug("_before-noisefilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult = noisefilter(
-            sheet, noisefilterIntensity, absWhiteThreshold, absBlackThreshold);
-        saveDebug("_after-noisefilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-noisefilter%d.pnm", nr, sheet);
+        uint64_t filterResult =
+            noisefilter(sheet, noisefilterIntensity, absWhiteThreshold);
+        saveDebug("_after-noisefilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRId64 " clusters.\n",
                    filterResult);
 
@@ -1679,12 +1661,10 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "blur-filter...");
 
-        saveDebug("_before-blurfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult = blurfilter(
-            sheet, blurfilterParams, absWhiteThreshold, absBlackThreshold);
-        saveDebug("_after-blurfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-blurfilter%d.pnm", nr, sheet);
+        uint64_t filterResult =
+            blurfilter(sheet, blurfilterParams, absWhiteThreshold);
+        saveDebug("_after-blurfilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
                    filterResult);
 
@@ -1703,11 +1683,9 @@ int main(int argc, char *argv[]) {
 
       // permanently apply masks
       if (maskCount > 0) {
-        saveDebug("_before-masking%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        apply_masks(sheet, masks, maskCount, maskColorPixel, absBlackThreshold);
-        saveDebug("_after-masking%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-masking%d.pnm", nr, sheet);
+        apply_masks(sheet, masks, maskCount, maskColorPixel);
+        saveDebug("_after-masking%d.pnm", nr, sheet);
       }
 
       // gray filter
@@ -1715,12 +1693,9 @@ int main(int argc, char *argv[]) {
                       options.ignore_multi_index)) {
         verboseLog(VERBOSE_NORMAL, "gray-filter...");
 
-        saveDebug("_before-grayfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
-        uint64_t filterResult =
-            grayfilter(sheet, grayfilterParams, absBlackThreshold);
-        saveDebug("_after-grayfilter%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-grayfilter%d.pnm", nr, sheet);
+        uint64_t filterResult = grayfilter(sheet, grayfilterParams);
+        saveDebug("_after-grayfilter%d.pnm", nr, sheet);
         verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
                    filterResult);
       } else {
@@ -1730,8 +1705,7 @@ int main(int argc, char *argv[]) {
       // rotation-detection
       if ((!isExcluded(nr, options.no_deskew_multi_index,
                        options.ignore_multi_index))) {
-        saveDebug("_before-deskew%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-deskew%d.pnm", nr, sheet);
 
         // detect masks again, we may get more precise results now after first
         // masking and grayfilter
@@ -1745,11 +1719,9 @@ int main(int argc, char *argv[]) {
 
         // auto-deskew each mask
         for (int i = 0; i < maskCount; i++) {
-          saveDebug("_before-deskew-detect%d.pnm", nr * maskCount + i, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_before-deskew-detect%d.pnm", nr * maskCount + i, sheet);
           float rotation = detect_rotation(sheet, masks[i], deskewParams);
-          saveDebug("_after-deskew-detect%d.pnm", nr * maskCount + i, sheet,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveDebug("_after-deskew-detect%d.pnm", nr * maskCount + i, sheet);
 
           verboseLog(VERBOSE_NORMAL, "rotate (%d,%d): %f\n", points[i].x,
                      points[i].y, rotation);
@@ -1763,23 +1735,21 @@ int main(int argc, char *argv[]) {
             // copy area to rotate into rSource
             copy_rectangle(sheet, rect,
                            (Rectangle){{masks[i].vertex[0], POINT_INFINITY}},
-                           POINT_ORIGIN, absBlackThreshold);
+                           POINT_ORIGIN);
 
             // rotate
-            rotate(rect, rectTarget, -rotation, absBlackThreshold,
-                   interpolateType);
+            rotate(rect, rectTarget, -rotation, interpolateType);
 
             // copy result back into whole image
             copy_rectangle(rectTarget, sheet, full_image(rectTarget),
-                           masks[i].vertex[0], absBlackThreshold);
+                           masks[i].vertex[0]);
 
             free_image(&rect);
             free_image(&rectTarget);
           }
         }
 
-        saveDebug("_after-deskew%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-deskew%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ deskewing DISABLED for sheet %d\n", nr);
       }
@@ -1799,15 +1769,12 @@ int main(int argc, char *argv[]) {
           verboseLog(VERBOSE_MORE, "(mask-scan before centering disabled)\n");
         }
 
-        saveDebug("_before-centering%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-centering%d.pnm", nr, sheet);
         // center masks on the sheet, according to their page position
         for (int i = 0; i < maskCount; i++) {
-          center_mask(sheet, points[i], masks[i], sheetBackgroundPixel,
-                      absBlackThreshold);
+          center_mask(sheet, points[i], masks[i]);
         }
-        saveDebug("_after-centering%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-centering%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ auto-centering DISABLED for sheet %d\n",
                    nr);
@@ -1816,7 +1783,7 @@ int main(int argc, char *argv[]) {
       // explicit wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, wipe, wipeCount, maskColorPixel, absBlackThreshold);
+        apply_wipes(sheet, wipe, wipeCount, maskColorPixel);
       } else {
         verboseLog(VERBOSE_MORE, "+ wipe DISABLED for sheet %d\n", nr);
       }
@@ -1824,7 +1791,7 @@ int main(int argc, char *argv[]) {
       // explicit border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, border, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, border, maskColorPixel);
       } else {
         verboseLog(VERBOSE_MORE, "+ border DISABLED for sheet %d\n", nr);
       }
@@ -1833,30 +1800,26 @@ int main(int argc, char *argv[]) {
       if (!isExcluded(nr, options.no_border_scan_multi_index,
                       options.ignore_multi_index)) {
         Rectangle autoborderMask[outsideBorderscanMaskCount];
-        saveDebug("_before-border%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-border%d.pnm", nr, sheet);
         for (int i = 0; i < outsideBorderscanMaskCount; i++) {
           autoborderMask[i] =
               border_to_mask(sheet, detect_border(sheet, borderScanParams,
-                                                  outsideBorderscanMask[i],
-                                                  absBlackThreshold));
+                                                  outsideBorderscanMask[i]));
         }
         apply_masks(sheet, autoborderMask, outsideBorderscanMaskCount,
-                    maskColorPixel, absBlackThreshold);
+                    maskColorPixel);
         for (int i = 0; i < outsideBorderscanMaskCount; i++) {
           // border-centering
           if (!isExcluded(nr, options.no_border_align_multi_index,
                           options.ignore_multi_index)) {
             align_mask(sheet, autoborderMask[i], outsideBorderscanMask[i],
-                       maskAlignmentParams, sheetBackgroundPixel,
-                       absBlackThreshold);
+                       maskAlignmentParams);
           } else {
             verboseLog(VERBOSE_MORE,
                        "+ border-centering DISABLED for sheet %d\n", nr);
           }
         }
-        saveDebug("_after-border%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_after-border%d.pnm", nr, sheet);
       } else {
         verboseLog(VERBOSE_MORE, "+ border-scan DISABLED for sheet %d\n", nr);
       }
@@ -1864,14 +1827,13 @@ int main(int argc, char *argv[]) {
       // post-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, postWipe, postWipeCount, maskColorPixel,
-                    absBlackThreshold);
+        apply_wipes(sheet, postWipe, postWipeCount, maskColorPixel);
       }
 
       // post-border
       if (!isExcluded(nr, options.no_border_multi_index,
                       options.ignore_multi_index)) {
-        apply_border(sheet, postBorder, maskColorPixel, absBlackThreshold);
+        apply_border(sheet, postBorder, maskColorPixel);
       }
 
       // post-mirroring
@@ -1879,7 +1841,7 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "post-mirroring %s\n",
                    getDirections(postMirror));
         mirror(sheet, !!(postMirror & (1 << HORIZONTAL)),
-               !!(postMirror & (1 << VERTICAL)), absBlackThreshold);
+               !!(postMirror & (1 << VERTICAL)));
       }
 
       // post-shifting
@@ -1887,14 +1849,13 @@ int main(int argc, char *argv[]) {
         verboseLog(VERBOSE_NORMAL, "post-shifting [%d,%d]\n", postShift[WIDTH],
                    postShift[HEIGHT]);
 
-        shift_image(&sheet, (Delta){postShift[WIDTH], postShift[HEIGHT]},
-                    sheetBackgroundPixel, absBlackThreshold);
+        shift_image(&sheet, (Delta){postShift[WIDTH], postShift[HEIGHT]});
       }
 
       // post-rotating
       if (postRotate != 0) {
         verboseLog(VERBOSE_NORMAL, "post-rotating %d degrees.\n", postRotate);
-        flip_rotate_90(&sheet, postRotate / 90, absBlackThreshold);
+        flip_rotate_90(&sheet, postRotate / 90);
       }
 
       // post-stretch
@@ -1912,8 +1873,7 @@ int main(int argc, char *argv[]) {
       w *= postZoomFactor;
       h *= postZoomFactor;
 
-      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                          absBlackThreshold);
+      stretch_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
 
       // post-size
       if ((postSize[WIDTH] != -1) || (postSize[HEIGHT] != -1)) {
@@ -1927,8 +1887,7 @@ int main(int argc, char *argv[]) {
         } else {
           h = sheet.frame->height;
         }
-        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType,
-                           sheetBackgroundPixel, absBlackThreshold);
+        resize_and_replace(&sheet, (RectangleSize){w, h}, interpolateType);
       }
 
       // --- write output file ---
@@ -1938,8 +1897,7 @@ int main(int argc, char *argv[]) {
       if (writeoutput == true) {
         verboseLog(VERBOSE_NORMAL, "writing output.\n");
         // write files
-        saveDebug("_before-save%d.pnm", nr, sheet, sheetBackgroundPixel,
-                  absBlackThreshold);
+        saveDebug("_before-save%d.pnm", nr, sheet);
 
         if (outputPixFmt == -1) {
           outputPixFmt = sheet.frame->format;
@@ -1957,12 +1915,11 @@ int main(int argc, char *argv[]) {
               (Rectangle){{{page.frame->width * j, 0},
                            {page.frame->width * j + page.frame->width,
                             page.frame->height}}},
-              POINT_ORIGIN, absBlackThreshold);
+              POINT_ORIGIN);
 
           verboseLog(VERBOSE_MORE, "saving file %s.\n", outputFileNames[j]);
 
-          saveImage(outputFileNames[j], page, outputPixFmt,
-                    sheetBackgroundPixel, absBlackThreshold);
+          saveImage(outputFileNames[j], page, outputPixFmt);
 
           free_image(&page);
         }

--- a/unpaper.h
+++ b/unpaper.h
@@ -28,11 +28,9 @@
 void loadImage(const char *filename, Image *image, Pixel sheet_background,
                uint8_t abs_black_threshold);
 
-void saveImage(char *filename, Image image, int outputPixFmt,
-               Pixel sheet_background, uint8_t abs_black_threshold);
+void saveImage(char *filename, Image image, int outputPixFmt);
 
-void saveDebug(char *filenameTemplate, int index, Image image,
-               Pixel sheet_background, uint8_t abs_black_threshold)
+void saveDebug(char *filenameTemplate, int index, Image image)
     __attribute__((format(printf, 1, 0)));
 
 /* --- arithmetic tool functions ------------------------------------------ */


### PR DESCRIPTION
Use per-format callbacks as part of the image get/set pixel.

These are indirect calls, but they avoid switch/case blocks in both
the get and set paths.
