### PR TITLE
Use the primitives to check if the point is in the image.

### DIFF
--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -20,8 +20,7 @@ static inline uint8_t pixel_grayscale(Pixel pixel) {
 static Pixel get_pixel_components(Image image, Point coords) {
   uint8_t *pix;
 
-  if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
-      (coords.y >= image.frame->height)) {
+  if (!point_in_rectangle(coords, full_image(image))) {
     return PIXEL_WHITE;
   }
 
@@ -135,9 +134,8 @@ uint8_t get_pixel_darkness_inverse(Image image, Point coords) {
 bool set_pixel(Image image, Point coords, Pixel pixel) {
   uint8_t *pix;
 
-  if ((coords.x < 0) || (coords.x >= image.frame->width) || (coords.y < 0) ||
-      (coords.y >= image.frame->height)) {
-    return false; // nop
+  if (!point_in_rectangle(coords, full_image(image))) {
+    return false;
   }
 
   bool pixel_black = pixel_grayscale(pixel) < image.abs_black_threshold;


### PR DESCRIPTION
Use the primitives to check if the point is in the image.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/189).
* #185
* #190
* __->__ #189