### PR TITLE
Make set_pixel a void return.

### DIFF
--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -12,18 +12,10 @@
  * Wipe a rectangular area of pixels with the defined color.
  * @return The number of pixels actually changed.
  */
-uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color) {
-  uint64_t count = 0;
-
+void wipe_rectangle(Image image, Rectangle input_area, Pixel color) {
   Rectangle area = clip_rectangle(image, input_area);
 
-  scan_rectangle(area) {
-    if (set_pixel(image, (Point){x, y}, color)) {
-      count++;
-    }
-  }
-
-  return count;
+  scan_rectangle(area) { set_pixel(image, (Point){x, y}, color); }
 }
 
 void copy_rectangle(Image source, Image target, Rectangle source_area,

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -10,7 +10,7 @@
 #include "imageprocess/interpolate.h"
 #include "imageprocess/primitives.h"
 
-uint64_t wipe_rectangle(Image image, Rectangle input_area, Pixel color);
+void wipe_rectangle(Image image, Rectangle input_area, Pixel color);
 void copy_rectangle(Image source, Image target, Rectangle source_area,
                     Point target_coords);
 uint8_t inverse_brightness_rect(Image image, Rectangle input_area);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -382,7 +382,8 @@ uint64_t grayfilter(Image image, GrayfilterParameters params) {
       uint8_t lightness = inverse_lightness_rect(image, area);
       // (lower threshold->more deletion)
       if (lightness < params.abs_threshold) {
-        result += wipe_rectangle(image, area, PIXEL_WHITE);
+        result += count_pixels(area);
+        wipe_rectangle(image, area, PIXEL_WHITE);
       }
     }
 

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -336,17 +336,11 @@ void apply_masks(Image image, const Rectangle masks[], size_t masks_count,
 void apply_wipes(Image image, Rectangle wipes[], size_t wipes_count,
                  Pixel color) {
   for (size_t i = 0; i < wipes_count; i++) {
-    uint64_t count = 0;
+    scan_rectangle(wipes[i]) { set_pixel(image, (Point){x, y}, color); }
 
-    scan_rectangle(wipes[i]) {
-      if (set_pixel(image, (Point){x, y}, color)) {
-        count++;
-      }
-    }
-
-    verboseLog(VERBOSE_MORE, "wipe [%d,%d,%d,%d]: %" PRIu64 " pixels\n",
-               wipes[i].vertex[0].x, wipes[i].vertex[0].y, wipes[i].vertex[1].x,
-               wipes[i].vertex[1].y, count);
+    verboseLog(VERBOSE_MORE, "wipe [%d,%d,%d,%d]\n", wipes[i].vertex[0].x,
+               wipes[i].vertex[0].y, wipes[i].vertex[1].x,
+               wipes[i].vertex[1].y);
   }
 }
 

--- a/imageprocess/pixel.c
+++ b/imageprocess/pixel.c
@@ -127,15 +127,12 @@ uint8_t get_pixel_darkness_inverse(Image image, Point coords) {
 
 /**
  * Sets the color/grayscale value of a single pixel.
- *
- * @return true if the pixel has been changed, false if the original color was
- * the one to set
  */
-bool set_pixel(Image image, Point coords, Pixel pixel) {
+void set_pixel(Image image, Point coords, Pixel pixel) {
   uint8_t *pix;
 
   if (!point_in_rectangle(coords, full_image(image))) {
-    return false;
+    return;
   }
 
   bool pixel_black = pixel_grayscale(pixel) < image.abs_black_threshold;
@@ -173,5 +170,4 @@ bool set_pixel(Image image, Point coords, Pixel pixel) {
   default:
     errOutput("unknown pixel format.");
   }
-  return true;
 }

--- a/imageprocess/pixel.h
+++ b/imageprocess/pixel.h
@@ -16,4 +16,4 @@ Pixel get_pixel(Image image, Point coords);
 uint8_t get_pixel_grayscale(Image image, Point coords);
 uint8_t get_pixel_lightness(Image image, Point coords);
 uint8_t get_pixel_darkness_inverse(Image image, Point coords);
-bool set_pixel(Image image, Point coords, Pixel pixel);
+void set_pixel(Image image, Point coords, Pixel pixel);


### PR DESCRIPTION
Make set_pixel a void return.

Instead of actually counting how many pixels were turned, just
return an approximation in the grayfilter like in everything else.

This allows dropping further counters and the boolean return.
