### PR TITLE
tests: print the generated command line.

### DIFF
--- a/tests/unpaper_tests.py
+++ b/tests/unpaper_tests.py
@@ -7,6 +7,7 @@ import logging
 import os
 import pathlib
 import re
+import shlex
 import subprocess
 import sys
 from typing import Sequence
@@ -45,7 +46,7 @@ def run_unpaper(
     unpaper_path = os.getenv("TEST_UNPAPER_BINARY", "unpaper")
 
     full_cmdline = [unpaper_path, "-vvv"] + list(cmdline)
-    print(f"Running {full_cmdline!r}")
+    print(f"Running {shlex.join(full_cmdline)}")
 
     return subprocess.run(
         full_cmdline,


### PR DESCRIPTION
tests: print the generated command line.

This just makes it easier to copy-paste from logs to the
terminal to run this in gdb.
