### PR TITLE
Remove parseInts/parseFloats parsers in favour of explicit validating parsers.

### DIFF
--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -18,21 +18,12 @@
  ***************/
 
 BlackfilterParameters validate_blackfilter_parameters(
-    uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
-    uint32_t scan_step_v, uint32_t scan_depth_h, uint32_t scan_depth_v,
-    int8_t scan_directions, float threshold, int32_t intensity,
-    size_t exclusions_count, Rectangle *exclusions) {
+    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
+    uint32_t scan_depth_v, int8_t scan_directions, float threshold,
+    int32_t intensity, size_t exclusions_count, Rectangle *exclusions) {
   return (BlackfilterParameters){
-      .scan_size =
-          {
-              .width = scan_size_h,
-              .height = scan_size_v,
-          },
-      .scan_step =
-          {
-              .horizontal = scan_step_h,
-              .vertical = scan_step_v,
-          },
+      .scan_size = scan_size,
+      .scan_step = scan_step,
       .scan_depth =
           {
               .horizontal = scan_depth_h,
@@ -134,22 +125,12 @@ void blackfilter(Image image, BlackfilterParameters params) {
  * Blurfilter *
  **************/
 
-BlurfilterParameters validate_blurfilter_parameters(uint32_t scan_size_h,
-                                                    uint32_t scan_size_v,
-                                                    uint32_t scan_step_h,
-                                                    uint32_t scan_step_v,
+BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
+                                                    Delta scan_step,
                                                     float intensity) {
   return (BlurfilterParameters){
-      .scan_size =
-          {
-              .width = scan_size_h,
-              .height = scan_size_v,
-          },
-      .scan_step =
-          {
-              .horizontal = scan_step_h,
-              .vertical = scan_step_v,
-          },
+      .scan_size = scan_size,
+      .scan_step = scan_step,
       .intensity = intensity,
   };
 }
@@ -348,22 +329,12 @@ uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level) {
  * Grayfilter *
  ***************/
 
-GrayfilterParameters validate_grayfilter_parameters(uint32_t scan_size_h,
-                                                    uint32_t scan_size_v,
-                                                    uint32_t scan_step_h,
-                                                    uint32_t scan_step_v,
+GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
+                                                    Delta scan_step,
                                                     float threshold) {
   return (GrayfilterParameters){
-      .scan_size =
-          {
-              .width = scan_size_h,
-              .height = scan_size_v,
-          },
-      .scan_step =
-          {
-              .horizontal = scan_step_h,
-              .vertical = scan_step_v,
-          },
+      .scan_size = scan_size,
+      .scan_step = scan_step,
       .abs_threshold = UINT8_MAX * threshold,
   };
 }

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -12,10 +12,7 @@
 typedef struct {
   RectangleSize scan_size;
 
-  struct {
-    uint32_t horizontal;
-    uint32_t vertical;
-  } scan_step;
+  Delta scan_step;
 
   struct {
     uint32_t horizontal;
@@ -35,26 +32,20 @@ typedef struct {
 void blackfilter(Image image, BlackfilterParameters params);
 
 BlackfilterParameters validate_blackfilter_parameters(
-    uint32_t scan_size_h, uint32_t scan_size_v, uint32_t scan_step_h,
-    uint32_t scan_step_v, uint32_t scan_depth_h, uint32_t scan_depth_v,
-    int8_t scan_directions, float threshold, int32_t intensity,
-    size_t exclusions_count, Rectangle *exclusions);
+    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
+    uint32_t scan_depth_v, int8_t scan_directions, float threshold,
+    int32_t intensity, size_t exclusions_count, Rectangle *exclusions);
 
 typedef struct {
   RectangleSize scan_size;
 
-  struct {
-    uint32_t horizontal;
-    uint32_t vertical;
-  } scan_step;
+  Delta scan_step;
 
   float intensity;
 } BlurfilterParameters;
 
-BlurfilterParameters validate_blurfilter_parameters(uint32_t scan_size_h,
-                                                    uint32_t scan_size_v,
-                                                    uint32_t scan_step_h,
-                                                    uint32_t scan_step_v,
+BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
+                                                    Delta scan_step,
                                                     float intensity);
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
@@ -65,18 +56,13 @@ uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level);
 typedef struct {
   RectangleSize scan_size;
 
-  struct {
-    uint32_t horizontal;
-    uint32_t vertical;
-  } scan_step;
+  Delta scan_step;
 
   uint8_t abs_threshold;
 } GrayfilterParameters;
 
-GrayfilterParameters validate_grayfilter_parameters(uint32_t scan_size_h,
-                                                    uint32_t scan_size_v,
-                                                    uint32_t scan_step_h,
-                                                    uint32_t scan_step_v,
+GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
+                                                    Delta scan_step,
                                                     float threshold);
 
 uint64_t grayfilter(Image image, GrayfilterParameters params);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -13,29 +13,20 @@
 #include "lib/logging.h"
 
 MaskDetectionParameters
-validate_mask_detection_parameters(int scan_directions,
-                                   const int scan_size[DIRECTIONS_COUNT],
+validate_mask_detection_parameters(int scan_directions, RectangleSize scan_size,
                                    const int scan_depth[DIRECTIONS_COUNT],
-                                   const int scan_step[DIRECTIONS_COUNT],
+                                   Delta scan_step,
                                    const float scan_threshold[DIRECTIONS_COUNT],
                                    const int scan_mininum[DIMENSIONS_COUNT],
                                    const int scan_maximum[DIMENSIONS_COUNT]) {
   return (MaskDetectionParameters){
-      .scan_size =
-          {
-              .width = scan_size[HORIZONTAL],
-              .height = scan_size[VERTICAL],
-          },
-      .scan_step =
-          {
-              .horizontal = scan_step[HORIZONTAL],
-              .vertical = scan_step[VERTICAL],
-          },
+      .scan_size = scan_size,
       .scan_depth =
           {
               .horizontal = scan_depth[HORIZONTAL],
               .vertical = scan_depth[VERTICAL],
           },
+      .scan_step = scan_step,
       .scan_threshold =
           {
               .horizontal = scan_threshold[HORIZONTAL],
@@ -373,21 +364,12 @@ void apply_border(Image image, const Border border, Pixel color) {
 }
 
 BorderScanParameters
-validate_border_scan_parameters(int scan_directions,
-                                const int scan_size[DIRECTIONS_COUNT],
-                                const int scan_step[DIRECTIONS_COUNT],
+validate_border_scan_parameters(int scan_directions, RectangleSize scan_size,
+                                Delta scan_step,
                                 const int scan_threshold[DIRECTIONS_COUNT]) {
   return (BorderScanParameters){
-      .scan_size =
-          {
-              .width = scan_size[HORIZONTAL],
-              .height = scan_size[VERTICAL],
-          },
-      .scan_step =
-          {
-              .horizontal = scan_step[HORIZONTAL],
-              .vertical = scan_step[VERTICAL],
-          },
+      .scan_size = scan_size,
+      .scan_step = scan_step,
       .scan_threshold =
           {
               .horizontal = scan_threshold[HORIZONTAL],

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -14,10 +14,7 @@
 typedef struct {
   RectangleSize scan_size;
 
-  struct {
-    int32_t horizontal;
-    int32_t vertical;
-  } scan_step;
+  Delta scan_step;
 
   struct {
     int32_t horizontal;
@@ -40,10 +37,9 @@ typedef struct {
 } MaskDetectionParameters;
 
 MaskDetectionParameters
-validate_mask_detection_parameters(int scan_directions,
-                                   const int scan_size[DIRECTIONS_COUNT],
-                                   const int scan_depth[DIRECTIONS_COUNT],
-                                   const int scan_step[DIRECTIONS_COUNT],
+validate_mask_detection_parameters(int scan_directions, RectangleSize scan_size,
+                                   const int32_t scan_depth[DIRECTIONS_COUNT],
+                                   Delta scan_step,
                                    const float scan_threshold[DIRECTIONS_COUNT],
                                    const int scan_mininum[DIMENSIONS_COUNT],
                                    const int scan_maximum[DIMENSIONS_COUNT]);
@@ -91,11 +87,7 @@ void apply_border(Image image, const Border border, Pixel color);
 
 typedef struct {
   RectangleSize scan_size;
-
-  struct {
-    int32_t horizontal;
-    int32_t vertical;
-  } scan_step;
+  Delta scan_step;
 
   struct {
     int32_t horizontal;
@@ -107,10 +99,9 @@ typedef struct {
 } BorderScanParameters;
 
 BorderScanParameters
-validate_border_scan_parameters(int scan_directions,
-                                const int scan_size[DIRECTIONS_COUNT],
-                                const int scan_step[DIRECTIONS_COUNT],
-                                const int scan_threshold[DIRECTIONS_COUNT]);
+validate_border_scan_parameters(int scan_directions, RectangleSize scan_size,
+                                Delta scan_step,
+                                const int32_t scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,
                      const Rectangle outside_mask);

--- a/lib/options.c
+++ b/lib/options.c
@@ -49,15 +49,107 @@ void options_init(Options *o) {
 }
 
 bool parse_rectangle(const char *str, Rectangle *rect) {
-  return sscanf(str, "%" SCNd32 ",%" SCNd32 ",%" SCNd32 ",%" SCNd32 "",
-                &rect->vertex[0].x, &rect->vertex[0].y, &rect->vertex[1].x,
-                &rect->vertex[1].y) == 4;
+  if (sscanf(str, "%" SCNd32 ",%" SCNd32 ",%" SCNd32 ",%" SCNd32 "",
+             &rect->vertex[0].x, &rect->vertex[0].y, &rect->vertex[1].x,
+             &rect->vertex[1].y) != 4) {
+    return false;
+  }
+
+  // only return true if the rectangle is valid!
+  return count_pixels(*rect) > 0;
 }
 
 int print_rectangle(Rectangle rect) {
   return printf("[%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 "] ",
                 rect.vertex[0].x, rect.vertex[0].y, rect.vertex[1].x,
                 rect.vertex[1].y);
+}
+
+/**
+ * Parses either a single integer as a size in pixel, or a pair of two
+ * integers, separated by a comma. If the second integer is missing,
+ * use the one integer for both width and height.
+ */
+bool parse_symmetric_integers(const char *str, int32_t *value_1,
+                              int32_t *value_2) {
+  switch (sscanf(str, "%" SCNd32 ",%" SCNd32 "", value_1, value_2)) {
+  case 1:
+    // only one value, copy over to the second.
+    *value_2 = *value_1;
+    // intentional fall-through.
+  case 2:
+    // both values provided (or fall-through.)
+    return true;
+  default:
+    // not enough / unparseable.
+    return false;
+  }
+}
+
+/**
+ * As above, but with floats.
+ */
+bool parse_symmetric_floats(const char *str, float *value_1, float *value_2) {
+  switch (sscanf(str, "%f,%f", value_1, value_2)) {
+  case 1:
+    // only one value, copy over to the second.
+    *value_2 = *value_1;
+    // intentional fall-through.
+  case 2:
+    // both values provided (or fall-through.)
+    return true;
+  default:
+    // not enough / unparseable.
+    return false;
+  }
+}
+bool parse_rectangle_size(const char *str, RectangleSize *size) {
+  if (!parse_symmetric_integers(str, &size->width, &size->height)) {
+    return false;
+  }
+
+  // only return true if the size is non-negative!
+  return size->width >= 0 && size->height >= 0;
+}
+
+int print_rectangle_size(RectangleSize size) {
+  return printf("[%" PRId32 ",%" PRId32 "] ", size.width, size.height);
+}
+
+bool parse_delta(const char *str, Delta *delta) {
+  return parse_symmetric_integers(str, &delta->horizontal, &delta->vertical);
+}
+
+/**
+ * Special case of parse_delta that validates the delta is positive.
+ */
+bool parse_scan_step(const char *str, Delta *delta) {
+  if (!parse_delta(str, delta)) {
+    return false;
+  }
+
+  return delta->horizontal > 0 && delta->vertical > 0;
+}
+
+int print_delta(Delta delta) {
+  return printf("[%" PRId32 ",%" PRId32 "] ", delta.horizontal, delta.vertical);
+}
+
+bool parse_border(const char *str, Border *border) {
+  if (sscanf(str, "%" SCNd32 ",%" SCNd32 ",%" SCNd32 ",%" SCNd32 "",
+             &border->left, &border->top, &border->right,
+             &border->bottom) != 4) {
+    return false;
+  }
+
+  // only return true if the border is valid!
+  return (border->left >= 0 && border->top >= 0 && border->right >= 0 &&
+          border->bottom >= 0);
+}
+
+int print_border(Border border) {
+  return printf("[%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 "] ",
+                border.left, border.top, border.right, border.bottom);
 }
 
 bool parse_color(const char *str, Pixel *color) {

--- a/lib/options.h
+++ b/lib/options.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 #include "constants.h"
+#include "imageprocess/masks.h"
 #include "imageprocess/primitives.h"
 #include "parse.h"
 
@@ -41,8 +42,22 @@ typedef struct {
 
 void options_init(Options *o);
 
+bool parse_symmetric_integers(const char *str, int32_t *value_1,
+                              int32_t *value_2);
+bool parse_symmetric_floats(const char *str, float *value_1, float *value_2);
+
 bool parse_rectangle(const char *str, Rectangle *rect);
 int print_rectangle(Rectangle rect);
+
+bool parse_rectangle_size(const char *str, RectangleSize *size);
+int print_rectangle_size(RectangleSize size);
+
+bool parse_delta(const char *str, Delta *delta);
+bool parse_scan_step(const char *str, Delta *delta);
+int print_delta(Delta delta);
+
+bool parse_border(const char *str, Border *rect);
+int print_border(Border rect);
 
 bool parse_color(const char *str, Pixel *color);
 int print_color(Pixel color);

--- a/parse.c
+++ b/parse.c
@@ -114,32 +114,6 @@ void printEdges(int d) {
 }
 
 /**
- * Parses either a single integer string, of a pair of two integers separated
- * by a comma.
- */
-void parseInts(char *s, int i[2]) {
-  i[0] = -1;
-  i[1] = -1;
-  sscanf(s, "%d,%d", &i[0], &i[1]);
-  if (i[1] == -1) {
-    i[1] = i[0]; // if second value is unset, copy first one into
-  }
-}
-
-/**
- * Parses either a single float string, of a pair of two floats separated
- * by a comma.
- */
-void parseFloats(char *s, float f[2]) {
-  f[0] = -1.0;
-  f[1] = -1.0;
-  sscanf(s, "%f,%f", &f[0], &f[1]);
-  if (f[1] == -1.0) {
-    f[1] = f[0]; // if second value is unset, copy first one into
-  }
-}
-
-/**
  * Combines an array of strings to a comma-separated string.
  */
 char *implode(char *buf, const char *s[], int cnt) {

--- a/parse.h
+++ b/parse.h
@@ -18,10 +18,6 @@ int parseEdges(char *s);
 
 void printEdges(int d);
 
-void parseInts(char *s, int i[2]);
-
-void parseFloats(char *s, float f[2]);
-
 char *implode(char *buf, const char *s[], int cnt);
 
 struct MultiIndex {


### PR DESCRIPTION
Remove parseInts/parseFloats parsers in favour of explicit validating parsers.

Not all of the options are particularly regular, so we still have a cop-out to parse symmetric ints and floats.

On the other hand, this allows passing more explicitly typed objects to the parameter validators, which is good.
