### PR TITLE
Move more of the processed parameters into the Options structure.

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -46,6 +46,15 @@ void options_init(Options *o) {
   o->no_border_multi_index = multi_index_empty();
   o->no_border_scan_multi_index = multi_index_empty();
   o->no_border_align_multi_index = multi_index_empty();
+
+  o->pre_shift = (Delta){0, 0};
+  o->post_shift = (Delta){0, 0};
+
+  o->sheet_size = (RectangleSize){-1, -1};
+  o->page_size = (RectangleSize){-1, -1};
+  o->post_page_size = (RectangleSize){-1, -1};
+  o->stretch_size = (RectangleSize){-1, -1};
+  o->post_stretch_size = (RectangleSize){-1, -1};
 }
 
 bool parse_rectangle(const char *str, Rectangle *rect) {

--- a/lib/options.h
+++ b/lib/options.h
@@ -38,6 +38,18 @@ typedef struct {
   struct MultiIndex no_border_multi_index;
   struct MultiIndex no_border_scan_multi_index;
   struct MultiIndex no_border_align_multi_index;
+
+  Delta pre_shift;
+  Delta post_shift;
+
+  RectangleSize sheet_size;
+  RectangleSize page_size;
+  RectangleSize post_page_size;
+  RectangleSize stretch_size;
+  RectangleSize post_stretch_size;
+
+  uint8_t abs_black_threshold;
+  uint8_t abs_white_threshold;
 } Options;
 
 void options_init(Options *o);


### PR DESCRIPTION
Move more of the processed parameters into the Options structure.

Eventually, the option parsing should only leave a read-only Options structure, that the processing
can then take as input and read from, without ever having to change the values.
