### PR TITLE
Make directions being a structure of two bools instead of an int of flags.

### DIFF
--- a/imageprocess/blit.c
+++ b/imageprocess/blit.c
@@ -245,15 +245,15 @@ void flip_rotate_90(Image *pImage, RotationDirection direction) {
   replace_image(pImage, &newimage);
 }
 
-void mirror(Image image, bool horizontal, bool vertical) {
+void mirror(Image image, Direction direction) {
   Rectangle source = {{POINT_ORIGIN, POINT_INFINITY}};
   RectangleSize image_size = size_of_image(image);
 
-  if (horizontal && !vertical) {
+  if (direction.horizontal && !direction.vertical) {
     source.vertex[1].x = (image_size.width - 1) / 2;
   }
 
-  if (vertical) {
+  if (direction.vertical) {
     source.vertex[1].y = (image_size.height - 1) / 2;
   }
 
@@ -261,15 +261,15 @@ void mirror(Image image, bool horizontal, bool vertical) {
 
   // Cannot use scan_rectangle() because of the midpoint turn.
   for (int32_t y = source.vertex[0].y; y <= source.vertex[1].y; y++) {
-    int32_t yy = vertical ? image_size.height - y - 1 : y;
+    int32_t yy = direction.vertical ? image_size.height - y - 1 : y;
     // Special case: the last middle line in odd-lined images that are
     // to be mirrored both horizontally and vertically.
-    if (vertical && horizontal && y == yy) {
+    if (direction.vertical && direction.horizontal && y == yy) {
       source.vertex[1].x = (image_size.width - 1) / 2;
     }
 
     for (int32_t x = 0; x <= source.vertex[1].x; x++) {
-      int32_t xx = horizontal ? image_size.width - x - 1 : x;
+      int32_t xx = direction.horizontal ? image_size.width - x - 1 : x;
 
       Point point1 = {x, y};
       Point point2 = {xx, yy};

--- a/imageprocess/blit.h
+++ b/imageprocess/blit.h
@@ -37,7 +37,7 @@ void resize_and_replace(Image *pImage, RectangleSize size,
 void flip_rotate_90(Image *pImage, RotationDirection direction);
 
 // Mirrors an image either horizontally, vertically, or both.
-void mirror(Image image, bool horizontal, bool vertical);
+void mirror(Image image, Direction direction);
 
 // Shifts the image.
 void shift_image(Image *pImage, Delta d);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -19,7 +19,7 @@
 
 BlackfilterParameters validate_blackfilter_parameters(
     RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, int8_t scan_directions, float threshold,
+    uint32_t scan_depth_v, Direction scan_direction, float threshold,
     int32_t intensity, size_t exclusions_count, Rectangle *exclusions) {
   return (BlackfilterParameters){
       .scan_size = scan_size,
@@ -30,8 +30,7 @@ BlackfilterParameters validate_blackfilter_parameters(
               .vertical = scan_depth_v,
           },
 
-      .scan_horizontal = !!(scan_directions & 1 << HORIZONTAL),
-      .scan_vertical = !!(scan_directions & 1 << VERTICAL),
+      .scan_direction = scan_direction,
 
       .abs_threshold = UINT8_MAX * threshold,
       .intensity = intensity,
@@ -105,7 +104,7 @@ static void blackfilter_scan(Image image, BlackfilterParameters params,
  */
 void blackfilter(Image image, BlackfilterParameters params) {
   // Left-to-Right scan.
-  if (params.scan_horizontal) {
+  if (params.scan_direction.horizontal) {
     blackfilter_scan(
         image, params, (Delta){params.scan_step.horizontal, 0},
         (RectangleSize){params.scan_size.width, params.scan_depth.vertical},
@@ -113,7 +112,7 @@ void blackfilter(Image image, BlackfilterParameters params) {
   }
 
   // To-to-Bottom scan.
-  if (params.scan_vertical) {
+  if (params.scan_direction.vertical) {
     blackfilter_scan(
         image, params, (Delta){0, params.scan_step.vertical},
         (RectangleSize){params.scan_depth.horizontal, params.scan_size.height},

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -19,8 +19,7 @@ typedef struct {
     uint32_t vertical;
   } scan_depth;
 
-  bool scan_horizontal;
-  bool scan_vertical;
+  Direction scan_direction;
 
   uint8_t abs_threshold;
   int32_t intensity;
@@ -33,7 +32,7 @@ void blackfilter(Image image, BlackfilterParameters params);
 
 BlackfilterParameters validate_blackfilter_parameters(
     RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, int8_t scan_directions, float threshold,
+    uint32_t scan_depth_v, Direction scan_direction, float threshold,
     int32_t intensity, size_t exclusions_count, Rectangle *exclusions);
 
 typedef struct {

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -21,8 +21,7 @@ typedef struct {
     int32_t vertical;
   } scan_depth;
 
-  bool scan_horizontal;
-  bool scan_vertical;
+  Direction scan_direction;
 
   struct {
     float horizontal;
@@ -36,13 +35,12 @@ typedef struct {
   int32_t maximum_height;
 } MaskDetectionParameters;
 
-MaskDetectionParameters
-validate_mask_detection_parameters(int scan_directions, RectangleSize scan_size,
-                                   const int32_t scan_depth[DIRECTIONS_COUNT],
-                                   Delta scan_step,
-                                   const float scan_threshold[DIRECTIONS_COUNT],
-                                   const int scan_mininum[DIMENSIONS_COUNT],
-                                   const int scan_maximum[DIMENSIONS_COUNT]);
+MaskDetectionParameters validate_mask_detection_parameters(
+    Direction scan_direction, RectangleSize scan_size,
+    const int32_t scan_depth[DIRECTIONS_COUNT], Delta scan_step,
+    const float scan_threshold[DIRECTIONS_COUNT],
+    const int scan_mininum[DIMENSIONS_COUNT],
+    const int scan_maximum[DIMENSIONS_COUNT]);
 
 size_t detect_masks(Image image, MaskDetectionParameters params,
                     const Point points[], size_t points_count,
@@ -100,13 +98,12 @@ typedef struct {
     int32_t vertical;
   } scan_threshold;
 
-  bool scan_horizontal;
-  bool scan_vertical;
+  Direction scan_direction;
 } BorderScanParameters;
 
 BorderScanParameters
-validate_border_scan_parameters(int scan_directions, RectangleSize scan_size,
-                                Delta scan_step,
+validate_border_scan_parameters(Direction scan_direction,
+                                RectangleSize scan_size, Delta scan_step,
                                 const int32_t scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -38,6 +38,20 @@ Point shift_point(Point p, Delta d);
   (Delta) { 1, 0 }
 
 typedef struct {
+  bool horizontal;
+  bool vertical;
+} Direction;
+
+#define DIRECTION_NONE                                                         \
+  (Direction) { .horizontal = false, .vertical = false }
+#define DIRECTION_HORIZONTAL                                                   \
+  (Direction) { .horizontal = true, .vertical = false }
+#define DIRECTION_VERTICAL                                                     \
+  (Direction) { .horizontal = false, .vertical = true }
+#define DIRECTION_BOTH                                                         \
+  (Direction) { .horizontal = true, .vertical = true }
+
+typedef struct {
   uint8_t r;
   uint8_t g;
   uint8_t b;

--- a/lib/options.c
+++ b/lib/options.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 
 #include "imageprocess/pixel.h"
 #include "lib/options.h"
@@ -208,4 +209,28 @@ int print_color(Pixel color) {
   }
 
   return printf("#%02x%02x%02x", color.r, color.g, color.b);
+}
+
+bool parse_direction(const char *str, Direction *direction) {
+  // This is a bit of a hack, but since there's no 'h' in "vertical", and
+  // no "v" in "horizontal", we can assume that if we find either of the
+  // two characters, the corresponding direction is selected.
+  direction->horizontal = !!(strchr(str, 'h') || strchr(str, 'H'));
+  direction->vertical = !!(strchr(str, 'v') || strchr(str, 'V'));
+
+  // if neither direction was selected, the only valid input is "none".
+  return direction->horizontal || direction->vertical ||
+         strcasecmp(str, "none") == 0;
+}
+
+const char *direction_to_string(Direction direction) {
+  if (direction.horizontal && direction.vertical) {
+    return "[horizontal,vertical]";
+  } else if (direction.horizontal) {
+    return "[horizontal]";
+  } else if (direction.vertical) {
+    return "[vertical]";
+  } else {
+    return "[none]";
+  }
 }

--- a/lib/options.h
+++ b/lib/options.h
@@ -75,3 +75,6 @@ int print_border(Border rect);
 
 bool parse_color(const char *str, Pixel *color);
 int print_color(Pixel color);
+
+bool parse_direction(const char *str, Direction *direction);
+const char *direction_to_string(Direction direction);

--- a/parse.c
+++ b/parse.c
@@ -19,41 +19,6 @@
 /* --- constants ---------------------------------------------------------- */
 
 /**
- * Parses a parameter string on occurrences of 'vertical', 'horizontal' or both.
- */
-int parseDirections(char *s) {
-  int dir = 0;
-  if (strchr(s, 'h') != 0) { // (there is no 'h' in 'vertical'...)
-    dir = 1 << HORIZONTAL;
-  }
-  if (strchr(s, 'v') != 0) { // (there is no 'v' in 'horizontal'...)
-    dir |= 1 << VERTICAL;
-  }
-  if (dir == 0)
-    errOutput(
-        "unknown direction name '%s', expected 'h[orizontal]' or 'v[ertical]'.",
-        s);
-
-  return dir;
-}
-
-/**
- * Prints whether directions are vertical, horizontal, or both.
- */
-const char *getDirections(int d) {
-  switch (d) {
-  case (1 << VERTICAL) | (1 << HORIZONTAL):
-    return "[vertical,horizontal]";
-  case (1 << VERTICAL):
-    return "[vertical]";
-  case (1 << HORIZONTAL):
-    return "[horizontal]";
-  }
-
-  return "[none]";
-}
-
-/**
  * Parses a parameter string on occurrences of 'left', 'top', 'right', 'bottom'
  * or combinations.
  */

--- a/parse.h
+++ b/parse.h
@@ -10,10 +10,6 @@
 
 /* --- tool functions for parameter parsing and verbose output ------------ */
 
-int parseDirections(char *s);
-
-const char *getDirections(int d);
-
 int parseEdges(char *s);
 
 void printEdges(int d);


### PR DESCRIPTION
Make directions being a structure of two bools instead of an int of flags.

We only have a handful of these cases, and as it turns out two booleans pack smaller than the `int`.
