### PR TITLE
Rewrite edge parsign and handling.

### DIFF
--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -18,18 +18,14 @@ static inline float degreesToRadians(float d) { return d * M_PI / 180.0; }
 DeskewParameters
 validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
                            float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, int deskewScanEdges) {
+                           float deskewScanDepth, Edges deskewScanEdges) {
   DeskewParameters params = {
       .deskewScanRangeRad = degreesToRadians(deskewScanRange),
       .deskewScanStepRad = degreesToRadians(deskewScanStep),
       .deskewScanDeviationRad = degreesToRadians(deskewScanDeviation),
       .deskewScanSize = deskewScanSize,
       .deskewScanDepth = deskewScanDepth,
-      .deskewEdgeLeft = deskewScanEdges & 1 << LEFT,
-      .deskewEdgeTop = deskewScanEdges & 1 << TOP,
-      .deskewEdgeRight = deskewScanEdges & 1 << RIGHT,
-      .deskewEdgeBottom = deskewScanEdges & 1 << BOTTOM,
-  };
+      .scan_edges = deskewScanEdges};
 
   return params;
 }
@@ -180,7 +176,7 @@ float detect_rotation(Image image, const Rectangle mask,
   float average;
   float deviation;
 
-  if (params.deskewEdgeLeft) {
+  if (params.scan_edges.left) {
     // left
     rotation[count] =
         detect_edge_rotation(image, mask, params, DELTA_RIGHTWARD);
@@ -189,7 +185,7 @@ float detect_rotation(Image image, const Rectangle mask,
                mask.vertex[1].y, rotation[count]);
     count++;
   }
-  if (params.deskewEdgeTop) {
+  if (params.scan_edges.top) {
     // top
     rotation[count] =
         -detect_edge_rotation(image, mask, params, DELTA_DOWNWARD);
@@ -198,7 +194,7 @@ float detect_rotation(Image image, const Rectangle mask,
                mask.vertex[1].y, rotation[count]);
     count++;
   }
-  if (params.deskewEdgeRight) {
+  if (params.scan_edges.right) {
     // right
     rotation[count] = detect_edge_rotation(image, mask, params, DELTA_LEFTWARD);
     verboseLog(VERBOSE_NORMAL, "detected rotation right: [%d,%d,%d,%d]: %f\n",
@@ -206,7 +202,7 @@ float detect_rotation(Image image, const Rectangle mask,
                mask.vertex[1].y, rotation[count]);
     count++;
   }
-  if (params.deskewEdgeBottom) {
+  if (params.scan_edges.bottom) {
     // bottom
     rotation[count] = -detect_edge_rotation(image, mask, params, DELTA_UPWARD);
     verboseLog(VERBOSE_NORMAL, "detected rotation bottom: [%d,%d,%d,%d]: %f\n",

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -16,16 +16,13 @@ typedef struct {
   float deskewScanDeviationRad;
   int deskewScanSize;
   float deskewScanDepth;
-  bool deskewEdgeLeft;
-  bool deskewEdgeTop;
-  bool deskewEdgeRight;
-  bool deskewEdgeBottom;
+  Edges scan_edges;
 } DeskewParameters;
 
 DeskewParameters
 validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
                            float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, int deskewScanEdges);
+                           float deskewScanDepth, Edges deskewScanEdges);
 
 float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -238,16 +238,10 @@ void center_mask(Image image, const Point center, const Rectangle area) {
   }
 }
 
-MaskAlignmentParameters validate_mask_alignment_parameters(int border_align,
+MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
                                                            Delta margin) {
   return (MaskAlignmentParameters){
-      .alignment =
-          {
-              .left = !!(border_align & (1 << LEFT)),
-              .top = !!(border_align & (1 << TOP)),
-              .right = !!(border_align & (1 << RIGHT)),
-              .bottom = !!(border_align & (1 << BOTTOM)),
-          },
+      .alignment = alignment,
       .margin = margin,
   };
 }

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -49,17 +49,11 @@ size_t detect_masks(Image image, MaskDetectionParameters params,
 void center_mask(Image image, const Point center, const Rectangle area);
 
 typedef struct {
-  struct {
-    bool left;
-    bool top;
-    bool right;
-    bool bottom;
-  } alignment;
-
+  Edges alignment;
   Delta margin;
 } MaskAlignmentParameters;
 
-MaskAlignmentParameters validate_mask_alignment_parameters(int border_align,
+MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
                                                            Delta margin);
 
 void align_mask(Image image, const Rectangle inside_area,

--- a/imageprocess/primitives.h
+++ b/imageprocess/primitives.h
@@ -52,6 +52,13 @@ typedef struct {
   (Direction) { .horizontal = true, .vertical = true }
 
 typedef struct {
+  bool left;
+  bool top;
+  bool right;
+  bool bottom;
+} Edges;
+
+typedef struct {
   uint8_t r;
   uint8_t g;
   uint8_t b;

--- a/lib/options.h
+++ b/lib/options.h
@@ -78,3 +78,6 @@ int print_color(Pixel color);
 
 bool parse_direction(const char *str, Direction *direction);
 const char *direction_to_string(Direction direction);
+
+bool parse_edges(const char *str, Edges *edges);
+int print_edges(Edges edges);

--- a/parse.c
+++ b/parse.c
@@ -19,66 +19,6 @@
 /* --- constants ---------------------------------------------------------- */
 
 /**
- * Parses a parameter string on occurrences of 'left', 'top', 'right', 'bottom'
- * or combinations.
- */
-int parseEdges(char *s) {
-  int dir = 0;
-  if (strstr(s, "left") != 0) {
-    dir = 1 << LEFT;
-  }
-  if (strstr(s, "top") != 0) {
-    dir |= 1 << TOP;
-  }
-  if (strstr(s, "right") != 0) {
-    dir |= 1 << RIGHT;
-  }
-  if (strstr(s, "bottom") != 0) {
-    dir |= 1 << BOTTOM;
-  }
-  if (dir == 0)
-    errOutput(
-        "unknown edge name '%s', expected 'left', 'top', 'right' or 'bottom'.",
-        s);
-
-  return dir;
-}
-
-/**
- * Prints whether edges are left, top, right, bottom or combinations.
- */
-void printEdges(int d) {
-  bool comma = false;
-
-  printf("[");
-  if ((d & 1 << LEFT) != 0) {
-    printf("left");
-    comma = true;
-  }
-  if ((d & 1 << TOP) != 0) {
-    if (comma == true) {
-      printf(",");
-    }
-    printf("top");
-    comma = true;
-  }
-  if ((d & 1 << RIGHT) != 0) {
-    if (comma == true) {
-      printf(",");
-    }
-    printf("right");
-    comma = true;
-  }
-  if ((d & 1 << BOTTOM) != 0) {
-    if (comma == true) {
-      printf(",");
-    }
-    printf("bottom");
-  }
-  printf("]\n");
-}
-
-/**
  * Combines an array of strings to a comma-separated string.
  */
 char *implode(char *buf, const char *s[], int cnt) {

--- a/parse.h
+++ b/parse.h
@@ -10,10 +10,6 @@
 
 /* --- tool functions for parameter parsing and verbose output ------------ */
 
-int parseEdges(char *s);
-
-void printEdges(int d);
-
 char *implode(char *buf, const char *s[], int cnt);
 
 struct MultiIndex {

--- a/unpaper.c
+++ b/unpaper.c
@@ -155,7 +155,8 @@ int main(int argc, char *argv[]) {
   int outputPixFmt = -1;
   Options options;
 
-  int deskewScanEdges = (1 << LEFT) | (1 << RIGHT);
+  Edges deskewScanEdges = {
+      .left = true, .top = false, .right = true, .bottom = false};
   int deskewScanSize = 1500;
   float deskewScanDepth = 0.5;
   float deskewScanRange = 5.0;
@@ -172,8 +173,9 @@ int main(int argc, char *argv[]) {
   RectangleSize borderScanSize = {5, 5};
   Delta borderScanStep = {5, 5};
   int32_t borderScanThreshold[DIRECTIONS_COUNT] = {5, 5};
-  int borderAlign = 0;                                 // center
-  MilsDelta borderAlignMarginPhysical = {0, 0, false}; // center
+  Edges borderAlign = {
+      .left = false, .top = false, .right = false, .bottom = false}; // center
+  MilsDelta borderAlignMarginPhysical = {0, 0, false};               // center
   Pixel maskColorPixel = PIXEL_WHITE;
   size_t pointCount = 0;
   Point points[MAX_POINTS];
@@ -781,7 +783,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_DESKEW_SCAN_DIRECTION:
-      deskewScanEdges = parseEdges(optarg);
+      if (!parse_edges(optarg, &deskewScanEdges)) {
+        errOutput("uanble to parse deskew-scan-direction: '%s'", optarg);
+      }
       break;
 
     case OPT_DESKEW_SCAN_SIZE:
@@ -835,7 +839,9 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_BORDER_ALIGN:
-      borderAlign = parseEdges(optarg);
+      if (!parse_edges(optarg, &borderAlign)) {
+        errOutput("unable to parse border-align: '%s'", optarg);
+      }
       break;
 
     case OPT_BORDER_MARGIN:
@@ -1396,7 +1402,7 @@ int main(int argc, char *argv[]) {
         }
         if (options.no_deskew_multi_index.count != -1) {
           printf("deskew-scan-direction: ");
-          printEdges(deskewScanEdges);
+          print_edges(deskewScanEdges);
           printf("deskew-scan-size: %d\n", deskewScanSize);
           printf("deskew-scan-depth: %f\n", deskewScanDepth);
           printf("deskew-scan-range: %f\n", deskewScanRange);
@@ -1446,7 +1452,7 @@ int main(int argc, char *argv[]) {
             printMultiIndex(options.no_border_scan_multi_index);
           }
           printf("border-align: ");
-          printEdges(borderAlign);
+          print_edges(borderAlign);
           printf("border-margin: [%d,%d]\n",
                  maskAlignmentParams.margin.horizontal,
                  maskAlignmentParams.margin.vertical);


### PR DESCRIPTION
Rewrite edge parsign and handling.

The new Edge structure has the same size as the previous bitmask, but
simplifies the flow of the code by just accessing forur booleans instead
of using bitwise math.

The parsing is changed and made a lot stricter, allowing only the tokens
themselves instead of a horrible mix of "leftrighttopbottom" which it did
before (despite the man page saying this should be comma-separated.)

On the other hand, the parsing is now case insensitive.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/204).
* #205
* __->__ #204