### PR TITLE
Rewrite interpolation parsing as a table lookup.

### DIFF
--- a/lib/options.c
+++ b/lib/options.c
@@ -326,3 +326,24 @@ int print_edges(Edges edges) {
       edges.right ? "right" : "", (edges.right && edges.bottom) ? "," : "",
       edges.bottom ? "bottom" : "");
 }
+
+static const struct {
+  const char name[8];
+  Interpolation interpolation;
+} INTERPOLATIONS[] = {
+    {"nearest", INTERP_NN},
+    {"linear", INTERP_LINEAR},
+    {"cubic", INTERP_CUBIC},
+};
+
+bool parse_interpolate(const char *str, Interpolation *interpolation) {
+  for (size_t j = 0; j < sizeof(INTERPOLATIONS) / sizeof(INTERPOLATIONS[0]);
+       j++) {
+    if (strcasecmp(str, INTERPOLATIONS[j].name) == 0) {
+      *interpolation = INTERPOLATIONS[j].interpolation;
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/lib/options.h
+++ b/lib/options.h
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 #include "constants.h"
+#include "imageprocess/interpolate.h"
 #include "imageprocess/masks.h"
 #include "imageprocess/primitives.h"
 #include "parse.h"
@@ -81,3 +82,5 @@ const char *direction_to_string(Direction direction);
 
 bool parse_edges(const char *str, Edges *edges);
 int print_edges(Edges edges);
+
+bool parse_interpolate(const char *str, Interpolation *interpolation);

--- a/unpaper.c
+++ b/unpaper.c
@@ -953,16 +953,8 @@ int main(int argc, char *argv[]) {
       break;
 
     case OPT_INTERPOLATE:
-      if (strcmp(optarg, "nearest") == 0) {
-        interpolateType = INTERP_NN;
-      } else if (strcmp(optarg, "linear") == 0) {
-        interpolateType = INTERP_LINEAR;
-      } else if (strcmp(optarg, "cubic") == 0) {
-        interpolateType = INTERP_CUBIC;
-      } else {
-        fprintf(stderr,
-                "Could not parse --interpolate, using cubic as default.\n");
-        interpolateType = INTERP_CUBIC;
+      if (!parse_interpolate(optarg, &interpolateType)) {
+        errOutput("unable to parse interpolate: '%s'", optarg);
       }
       break;
     }


### PR DESCRIPTION
Rewrite interpolation parsing as a table lookup.

This matches other options passed in, and makes it case-insensitive.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/205).
* #207
* #206
* __->__ #205