### PR TITLE
Rewrite layout parsing as a table lookup.

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -35,4 +35,4 @@ typedef enum {
   LAYOUT_SINGLE,
   LAYOUT_DOUBLE,
   LAYOUTS_COUNT
-} LAYOUTS;
+} Layout;

--- a/lib/options.c
+++ b/lib/options.c
@@ -329,6 +329,26 @@ int print_edges(Edges edges) {
 
 static const struct {
   const char name[8];
+  Layout layout;
+} LAYOUTS[] = {
+    {"single", LAYOUT_SINGLE},
+    {"double", LAYOUT_DOUBLE},
+    {"none", LAYOUT_NONE},
+};
+
+bool parse_layout(const char *str, Layout *layout) {
+  for (size_t j = 0; j < sizeof(LAYOUTS) / sizeof(LAYOUTS[0]); j++) {
+    if (strcasecmp(str, LAYOUTS[j].name) == 0) {
+      *layout = LAYOUTS[j].layout;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static const struct {
+  const char name[8];
   Interpolation interpolation;
 } INTERPOLATIONS[] = {
     {"nearest", INTERP_NN},

--- a/lib/options.h
+++ b/lib/options.h
@@ -13,7 +13,7 @@
 #include "parse.h"
 
 typedef struct {
-  LAYOUTS layout;
+  Layout layout;
   int start_sheet;
   int end_sheet;
   int start_input;
@@ -82,5 +82,7 @@ const char *direction_to_string(Direction direction);
 
 bool parse_edges(const char *str, Edges *edges);
 int print_edges(Edges edges);
+
+bool parse_layout(const char *str, Layout *layout);
 
 bool parse_interpolate(const char *str, Interpolation *interpolation);

--- a/unpaper.c
+++ b/unpaper.c
@@ -427,14 +427,8 @@ int main(int argc, char *argv[]) {
       return 0;
 
     case 'l':
-      if (strcmp(optarg, "single") == 0) {
-        options.layout = LAYOUT_SINGLE;
-      } else if (strcmp(optarg, "double") == 0) {
-        options.layout = LAYOUT_DOUBLE;
-      } else if (strcmp(optarg, "none") == 0) {
-        options.layout = LAYOUT_NONE;
-      } else {
-        errOutput("unknown layout mode '%s'.", optarg);
+      if (!parse_layout(optarg, &options.layout)) {
+        errOutput("unable to parse layout: '%s'", optarg);
       }
       break;
 


### PR DESCRIPTION
Rewrite layout parsing as a table lookup.

This also makes the parameter case insensitive.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/207).
* #208
* __->__ #207