### PR TITLE
Make all parameters structures part of Options.

### DIFF
--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -18,11 +18,11 @@
 
 static inline float degreesToRadians(float d) { return d * M_PI / 180.0; }
 
-DeskewParameters
-validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
-                           float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, Edges deskewScanEdges) {
-  DeskewParameters params = {
+bool validate_deskew_parameters(DeskewParameters *params, float deskewScanRange,
+                                float deskewScanStep, float deskewScanDeviation,
+                                int deskewScanSize, float deskewScanDepth,
+                                Edges deskewScanEdges) {
+  *params = (DeskewParameters){
       .deskewScanRangeRad = degreesToRadians(deskewScanRange),
       .deskewScanStepRad = degreesToRadians(deskewScanStep),
       .deskewScanDeviationRad = degreesToRadians(deskewScanDeviation),
@@ -30,7 +30,7 @@ validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
       .deskewScanDepth = deskewScanDepth,
       .scan_edges = deskewScanEdges};
 
-  return params;
+  return true;
 }
 
 /**

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -19,10 +19,10 @@ typedef struct {
   Edges scan_edges;
 } DeskewParameters;
 
-DeskewParameters
-validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
-                           float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, Edges deskewScanEdges);
+bool validate_deskew_parameters(DeskewParameters *params, float deskewScanRange,
+                                float deskewScanStep, float deskewScanDeviation,
+                                int deskewScanSize, float deskewScanDepth,
+                                Edges deskewScanEdges);
 
 float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -17,11 +17,14 @@
  * Blackfilter *
  ***************/
 
-BlackfilterParameters validate_blackfilter_parameters(
-    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, Direction scan_direction, float threshold,
-    int32_t intensity, size_t exclusions_count, Rectangle *exclusions) {
-  return (BlackfilterParameters){
+bool validate_blackfilter_parameters(BlackfilterParameters *params,
+                                     RectangleSize scan_size, Delta scan_step,
+                                     uint32_t scan_depth_h,
+                                     uint32_t scan_depth_v,
+                                     Direction scan_direction, float threshold,
+                                     int32_t intensity, size_t exclusions_count,
+                                     Rectangle *exclusions) {
+  *params = (BlackfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .scan_depth =
@@ -38,6 +41,8 @@ BlackfilterParameters validate_blackfilter_parameters(
       .exclusions_count = exclusions_count,
       .exclusions = exclusions,
   };
+
+  return true;
 }
 
 static void blackfilter_scan(Image image, BlackfilterParameters params,
@@ -124,14 +129,16 @@ void blackfilter(Image image, BlackfilterParameters params) {
  * Blurfilter *
  **************/
 
-BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float intensity) {
-  return (BlurfilterParameters){
+bool validate_blurfilter_parameters(BlurfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float intensity) {
+  *params = (BlurfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .intensity = intensity,
   };
+
+  return true;
 }
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
@@ -328,14 +335,16 @@ uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level) {
  * Grayfilter *
  ***************/
 
-GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float threshold) {
-  return (GrayfilterParameters){
+bool validate_grayfilter_parameters(GrayfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float threshold) {
+  *params = (GrayfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .abs_threshold = UINT8_MAX * threshold,
   };
+
+  return true;
 }
 
 uint64_t grayfilter(Image image, GrayfilterParameters params) {

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -30,10 +30,13 @@ typedef struct {
 
 void blackfilter(Image image, BlackfilterParameters params);
 
-BlackfilterParameters validate_blackfilter_parameters(
-    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, Direction scan_direction, float threshold,
-    int32_t intensity, size_t exclusions_count, Rectangle *exclusions);
+bool validate_blackfilter_parameters(BlackfilterParameters *params,
+                                     RectangleSize scan_size, Delta scan_step,
+                                     uint32_t scan_depth_h,
+                                     uint32_t scan_depth_v,
+                                     Direction scan_direction, float threshold,
+                                     int32_t intensity, size_t exclusions_count,
+                                     Rectangle *exclusions);
 
 typedef struct {
   RectangleSize scan_size;
@@ -43,9 +46,9 @@ typedef struct {
   float intensity;
 } BlurfilterParameters;
 
-BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float intensity);
+bool validate_blurfilter_parameters(BlurfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float intensity);
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
                     uint8_t abs_white_threshold);
@@ -60,8 +63,8 @@ typedef struct {
   uint8_t abs_threshold;
 } GrayfilterParameters;
 
-GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float threshold);
+bool validate_grayfilter_parameters(GrayfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float threshold);
 
 uint64_t grayfilter(Image image, GrayfilterParameters params);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -12,13 +12,13 @@
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
 
-MaskDetectionParameters validate_mask_detection_parameters(
-    Direction scan_direction, RectangleSize scan_size,
-    const int scan_depth[DIRECTIONS_COUNT], Delta scan_step,
-    const float scan_threshold[DIRECTIONS_COUNT],
+bool validate_mask_detection_parameters(
+    MaskDetectionParameters *params, Direction scan_direction,
+    RectangleSize scan_size, const int scan_depth[DIRECTIONS_COUNT],
+    Delta scan_step, const float scan_threshold[DIRECTIONS_COUNT],
     const int scan_mininum[DIMENSIONS_COUNT],
     const int scan_maximum[DIMENSIONS_COUNT]) {
-  return (MaskDetectionParameters){
+  *params = (MaskDetectionParameters){
       .scan_size = scan_size,
       .scan_depth =
           {
@@ -40,6 +40,8 @@ MaskDetectionParameters validate_mask_detection_parameters(
       .minimum_height = scan_mininum[VERTICAL],
       .maximum_height = scan_maximum[VERTICAL],
   };
+
+  return true;
 }
 
 /**
@@ -238,12 +240,14 @@ void center_mask(Image image, const Point center, const Rectangle area) {
   }
 }
 
-MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
-                                                           Delta margin) {
-  return (MaskAlignmentParameters){
+bool validate_mask_alignment_parameters(MaskAlignmentParameters *params,
+                                        Edges alignment, Delta margin) {
+  *params = (MaskAlignmentParameters){
       .alignment = alignment,
       .margin = margin,
   };
+
+  return true;
 }
 
 /**
@@ -355,11 +359,11 @@ void apply_border(Image image, const Border border, Pixel color) {
   apply_masks(image, &mask, 1, color);
 }
 
-BorderScanParameters
-validate_border_scan_parameters(Direction scan_direction,
-                                RectangleSize scan_size, Delta scan_step,
-                                const int scan_threshold[DIRECTIONS_COUNT]) {
-  return (BorderScanParameters){
+bool validate_border_scan_parameters(
+    BorderScanParameters *params, Direction scan_direction,
+    RectangleSize scan_size, Delta scan_step,
+    const int scan_threshold[DIRECTIONS_COUNT]) {
+  *params = (BorderScanParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .scan_threshold =
@@ -370,6 +374,8 @@ validate_border_scan_parameters(Direction scan_direction,
 
       .scan_direction = scan_direction,
   };
+
+  return true;
 }
 
 /**

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -35,10 +35,10 @@ typedef struct {
   int32_t maximum_height;
 } MaskDetectionParameters;
 
-MaskDetectionParameters validate_mask_detection_parameters(
-    Direction scan_direction, RectangleSize scan_size,
-    const int32_t scan_depth[DIRECTIONS_COUNT], Delta scan_step,
-    const float scan_threshold[DIRECTIONS_COUNT],
+bool validate_mask_detection_parameters(
+    MaskDetectionParameters *params, Direction scan_direction,
+    RectangleSize scan_size, const int32_t scan_depth[DIRECTIONS_COUNT],
+    Delta scan_step, const float scan_threshold[DIRECTIONS_COUNT],
     const int scan_mininum[DIMENSIONS_COUNT],
     const int scan_maximum[DIMENSIONS_COUNT]);
 
@@ -53,8 +53,8 @@ typedef struct {
   Delta margin;
 } MaskAlignmentParameters;
 
-MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
-                                                           Delta margin);
+bool validate_mask_alignment_parameters(MaskAlignmentParameters *params,
+                                        Edges alignment, Delta margin);
 
 void align_mask(Image image, const Rectangle inside_area,
                 const Rectangle outside, MaskAlignmentParameters params);
@@ -95,10 +95,10 @@ typedef struct {
   Direction scan_direction;
 } BorderScanParameters;
 
-BorderScanParameters
-validate_border_scan_parameters(Direction scan_direction,
-                                RectangleSize scan_size, Delta scan_step,
-                                const int32_t scan_threshold[DIRECTIONS_COUNT]);
+bool validate_border_scan_parameters(
+    BorderScanParameters *params, Direction scan_direction,
+    RectangleSize scan_size, Delta scan_step,
+    const int32_t scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,
                      const Rectangle outside_mask);

--- a/lib/options.h
+++ b/lib/options.h
@@ -7,6 +7,8 @@
 #include <stdbool.h>
 
 #include "constants.h"
+#include "imageprocess/deskew.h"
+#include "imageprocess/filters.h"
 #include "imageprocess/interpolate.h"
 #include "imageprocess/masks.h"
 #include "imageprocess/primitives.h"
@@ -51,6 +53,15 @@ typedef struct {
 
   uint8_t abs_black_threshold;
   uint8_t abs_white_threshold;
+
+  DeskewParameters deskew_parameters;
+  MaskDetectionParameters mask_detection_parameters;
+  MaskAlignmentParameters mask_alignment_parameters;
+  BorderScanParameters border_scan_parameters;
+
+  GrayfilterParameters grayfilter_parameters;
+  BlackfilterParameters blackfilter_parameters;
+  BlurfilterParameters blurfilter_parameters;
 } Options;
 
 void options_init(Options *o);


### PR DESCRIPTION
Make all parameters structures part of Options.

This changes the various validators for mask/deskew/filters to return a boolean,
and set the various parameters in the Options structure, instead of returning
a new one.

In turn, this makes it easier to split the scope of temporary variables for options
parsing.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/209).
* #210
* __->__ #209