### PR TITLE
When applying per-input adjustment, make sure to update them in the parameters.

### DIFF
--- a/imageprocess/deskew.c
+++ b/imageprocess/deskew.c
@@ -18,11 +18,11 @@
 
 static inline float degreesToRadians(float d) { return d * M_PI / 180.0; }
 
-DeskewParameters
-validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
-                           float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, Edges deskewScanEdges) {
-  DeskewParameters params = {
+bool validate_deskew_parameters(DeskewParameters *params, float deskewScanRange,
+                                float deskewScanStep, float deskewScanDeviation,
+                                int deskewScanSize, float deskewScanDepth,
+                                Edges deskewScanEdges) {
+  *params = (DeskewParameters){
       .deskewScanRangeRad = degreesToRadians(deskewScanRange),
       .deskewScanStepRad = degreesToRadians(deskewScanStep),
       .deskewScanDeviationRad = degreesToRadians(deskewScanDeviation),
@@ -30,7 +30,7 @@ validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
       .deskewScanDepth = deskewScanDepth,
       .scan_edges = deskewScanEdges};
 
-  return params;
+  return true;
 }
 
 /**

--- a/imageprocess/deskew.h
+++ b/imageprocess/deskew.h
@@ -19,10 +19,10 @@ typedef struct {
   Edges scan_edges;
 } DeskewParameters;
 
-DeskewParameters
-validate_deskew_parameters(float deskewScanRange, float deskewScanStep,
-                           float deskewScanDeviation, int deskewScanSize,
-                           float deskewScanDepth, Edges deskewScanEdges);
+bool validate_deskew_parameters(DeskewParameters *params, float deskewScanRange,
+                                float deskewScanStep, float deskewScanDeviation,
+                                int deskewScanSize, float deskewScanDepth,
+                                Edges deskewScanEdges);
 
 float detect_rotation(Image image, Rectangle mask,
                       const DeskewParameters params);

--- a/imageprocess/filters.c
+++ b/imageprocess/filters.c
@@ -17,11 +17,14 @@
  * Blackfilter *
  ***************/
 
-BlackfilterParameters validate_blackfilter_parameters(
-    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, Direction scan_direction, float threshold,
-    int32_t intensity, size_t exclusions_count, Rectangle *exclusions) {
-  return (BlackfilterParameters){
+bool validate_blackfilter_parameters(BlackfilterParameters *params,
+                                     RectangleSize scan_size, Delta scan_step,
+                                     uint32_t scan_depth_h,
+                                     uint32_t scan_depth_v,
+                                     Direction scan_direction, float threshold,
+                                     int32_t intensity, size_t exclusions_count,
+                                     Rectangle *exclusions) {
+  *params = (BlackfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .scan_depth =
@@ -38,6 +41,8 @@ BlackfilterParameters validate_blackfilter_parameters(
       .exclusions_count = exclusions_count,
       .exclusions = exclusions,
   };
+
+  return true;
 }
 
 static void blackfilter_scan(Image image, BlackfilterParameters params,
@@ -124,14 +129,16 @@ void blackfilter(Image image, BlackfilterParameters params) {
  * Blurfilter *
  **************/
 
-BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float intensity) {
-  return (BlurfilterParameters){
+bool validate_blurfilter_parameters(BlurfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float intensity) {
+  *params = (BlurfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .intensity = intensity,
   };
+
+  return true;
 }
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
@@ -328,14 +335,16 @@ uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level) {
  * Grayfilter *
  ***************/
 
-GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float threshold) {
-  return (GrayfilterParameters){
+bool validate_grayfilter_parameters(GrayfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float threshold) {
+  *params = (GrayfilterParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .abs_threshold = UINT8_MAX * threshold,
   };
+
+  return true;
 }
 
 uint64_t grayfilter(Image image, GrayfilterParameters params) {

--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -30,10 +30,13 @@ typedef struct {
 
 void blackfilter(Image image, BlackfilterParameters params);
 
-BlackfilterParameters validate_blackfilter_parameters(
-    RectangleSize scan_size, Delta scan_step, uint32_t scan_depth_h,
-    uint32_t scan_depth_v, Direction scan_direction, float threshold,
-    int32_t intensity, size_t exclusions_count, Rectangle *exclusions);
+bool validate_blackfilter_parameters(BlackfilterParameters *params,
+                                     RectangleSize scan_size, Delta scan_step,
+                                     uint32_t scan_depth_h,
+                                     uint32_t scan_depth_v,
+                                     Direction scan_direction, float threshold,
+                                     int32_t intensity, size_t exclusions_count,
+                                     Rectangle *exclusions);
 
 typedef struct {
   RectangleSize scan_size;
@@ -43,9 +46,9 @@ typedef struct {
   float intensity;
 } BlurfilterParameters;
 
-BlurfilterParameters validate_blurfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float intensity);
+bool validate_blurfilter_parameters(BlurfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float intensity);
 
 uint64_t blurfilter(Image image, BlurfilterParameters params,
                     uint8_t abs_white_threshold);
@@ -60,8 +63,8 @@ typedef struct {
   uint8_t abs_threshold;
 } GrayfilterParameters;
 
-GrayfilterParameters validate_grayfilter_parameters(RectangleSize scan_size,
-                                                    Delta scan_step,
-                                                    float threshold);
+bool validate_grayfilter_parameters(GrayfilterParameters *params,
+                                    RectangleSize scan_size, Delta scan_step,
+                                    float threshold);
 
 uint64_t grayfilter(Image image, GrayfilterParameters params);

--- a/imageprocess/masks.c
+++ b/imageprocess/masks.c
@@ -12,13 +12,13 @@
 #include "imageprocess/primitives.h"
 #include "lib/logging.h"
 
-MaskDetectionParameters validate_mask_detection_parameters(
-    Direction scan_direction, RectangleSize scan_size,
-    const int scan_depth[DIRECTIONS_COUNT], Delta scan_step,
-    const float scan_threshold[DIRECTIONS_COUNT],
+bool validate_mask_detection_parameters(
+    MaskDetectionParameters *params, Direction scan_direction,
+    RectangleSize scan_size, const int scan_depth[DIRECTIONS_COUNT],
+    Delta scan_step, const float scan_threshold[DIRECTIONS_COUNT],
     const int scan_mininum[DIMENSIONS_COUNT],
     const int scan_maximum[DIMENSIONS_COUNT]) {
-  return (MaskDetectionParameters){
+  *params = (MaskDetectionParameters){
       .scan_size = scan_size,
       .scan_depth =
           {
@@ -40,6 +40,8 @@ MaskDetectionParameters validate_mask_detection_parameters(
       .minimum_height = scan_mininum[VERTICAL],
       .maximum_height = scan_maximum[VERTICAL],
   };
+
+  return true;
 }
 
 /**
@@ -238,12 +240,14 @@ void center_mask(Image image, const Point center, const Rectangle area) {
   }
 }
 
-MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
-                                                           Delta margin) {
-  return (MaskAlignmentParameters){
+bool validate_mask_alignment_parameters(MaskAlignmentParameters *params,
+                                        Edges alignment, Delta margin) {
+  *params = (MaskAlignmentParameters){
       .alignment = alignment,
       .margin = margin,
   };
+
+  return true;
 }
 
 /**
@@ -355,11 +359,11 @@ void apply_border(Image image, const Border border, Pixel color) {
   apply_masks(image, &mask, 1, color);
 }
 
-BorderScanParameters
-validate_border_scan_parameters(Direction scan_direction,
-                                RectangleSize scan_size, Delta scan_step,
-                                const int scan_threshold[DIRECTIONS_COUNT]) {
-  return (BorderScanParameters){
+bool validate_border_scan_parameters(
+    BorderScanParameters *params, Direction scan_direction,
+    RectangleSize scan_size, Delta scan_step,
+    const int scan_threshold[DIRECTIONS_COUNT]) {
+  *params = (BorderScanParameters){
       .scan_size = scan_size,
       .scan_step = scan_step,
       .scan_threshold =
@@ -370,6 +374,8 @@ validate_border_scan_parameters(Direction scan_direction,
 
       .scan_direction = scan_direction,
   };
+
+  return true;
 }
 
 /**

--- a/imageprocess/masks.h
+++ b/imageprocess/masks.h
@@ -35,10 +35,10 @@ typedef struct {
   int32_t maximum_height;
 } MaskDetectionParameters;
 
-MaskDetectionParameters validate_mask_detection_parameters(
-    Direction scan_direction, RectangleSize scan_size,
-    const int32_t scan_depth[DIRECTIONS_COUNT], Delta scan_step,
-    const float scan_threshold[DIRECTIONS_COUNT],
+bool validate_mask_detection_parameters(
+    MaskDetectionParameters *params, Direction scan_direction,
+    RectangleSize scan_size, const int32_t scan_depth[DIRECTIONS_COUNT],
+    Delta scan_step, const float scan_threshold[DIRECTIONS_COUNT],
     const int scan_mininum[DIMENSIONS_COUNT],
     const int scan_maximum[DIMENSIONS_COUNT]);
 
@@ -53,8 +53,8 @@ typedef struct {
   Delta margin;
 } MaskAlignmentParameters;
 
-MaskAlignmentParameters validate_mask_alignment_parameters(Edges alignment,
-                                                           Delta margin);
+bool validate_mask_alignment_parameters(MaskAlignmentParameters *params,
+                                        Edges alignment, Delta margin);
 
 void align_mask(Image image, const Rectangle inside_area,
                 const Rectangle outside, MaskAlignmentParameters params);
@@ -95,10 +95,10 @@ typedef struct {
   Direction scan_direction;
 } BorderScanParameters;
 
-BorderScanParameters
-validate_border_scan_parameters(Direction scan_direction,
-                                RectangleSize scan_size, Delta scan_step,
-                                const int32_t scan_threshold[DIRECTIONS_COUNT]);
+bool validate_border_scan_parameters(
+    BorderScanParameters *params, Direction scan_direction,
+    RectangleSize scan_size, Delta scan_step,
+    const int32_t scan_threshold[DIRECTIONS_COUNT]);
 
 Border detect_border(Image image, BorderScanParameters params,
                      const Rectangle outside_mask);

--- a/lib/options.h
+++ b/lib/options.h
@@ -7,6 +7,8 @@
 #include <stdbool.h>
 
 #include "constants.h"
+#include "imageprocess/deskew.h"
+#include "imageprocess/filters.h"
 #include "imageprocess/interpolate.h"
 #include "imageprocess/masks.h"
 #include "imageprocess/primitives.h"
@@ -51,6 +53,15 @@ typedef struct {
 
   uint8_t abs_black_threshold;
   uint8_t abs_white_threshold;
+
+  DeskewParameters deskew_parameters;
+  MaskDetectionParameters mask_detection_parameters;
+  MaskAlignmentParameters mask_alignment_parameters;
+  BorderScanParameters border_scan_parameters;
+
+  GrayfilterParameters grayfilter_parameters;
+  BlackfilterParameters blackfilter_parameters;
+  BlurfilterParameters blurfilter_parameters;
 } Options;
 
 void options_init(Options *o);

--- a/unpaper.c
+++ b/unpaper.c
@@ -1551,20 +1551,23 @@ int main(int argc, char *argv[]) {
           points[pointCount++] =
               (Point){sheet.frame->width / 2, sheet.frame->height / 2};
         }
-        if (maskScanMaximum[WIDTH] == -1) {
-          maskScanMaximum[WIDTH] = sheet.frame->width;
+        if (options.mask_detection_parameters.maximum_width == -1) {
+          options.mask_detection_parameters.maximum_width = sheet.frame->width;
         }
-        if (maskScanMaximum[HEIGHT] == -1) {
-          maskScanMaximum[HEIGHT] = sheet.frame->height;
+        if (options.mask_detection_parameters.maximum_height == -1) {
+          options.mask_detection_parameters.maximum_height =
+              sheet.frame->height;
         }
         // avoid inner half of the sheet to be blackfilter-detectable
-        if (blackfilterExcludeCount ==
-            0) { // no manual settings, use auto-values
+        if (options.blackfilter_parameters.exclusions_count == 0) {
+          // no manual settings, use auto-values
           RectangleSize sheetSize = size_of_image(sheet);
-          blackfilterExclude[blackfilterExcludeCount++] = rectangle_from_size(
-              (Point){sheetSize.width / 4, sheetSize.height / 4},
-              (RectangleSize){.width = sheetSize.width / 2,
-                              .height = sheetSize.height / 2});
+          options.blackfilter_parameters
+              .exclusions[options.blackfilter_parameters.exclusions_count++] =
+              rectangle_from_size(
+                  (Point){sheetSize.width / 4, sheetSize.height / 4},
+                  (RectangleSize){.width = sheetSize.width / 2,
+                                  .height = sheetSize.height / 2});
         }
         // set single outside border to start scanning for final border-scan
         if (outsideBorderscanMaskCount ==
@@ -1584,11 +1587,13 @@ int main(int argc, char *argv[]) {
               (Point){sheet.frame->width - sheet.frame->width / 4,
                       sheet.frame->height / 2};
         }
-        if (maskScanMaximum[WIDTH] == -1) {
-          maskScanMaximum[WIDTH] = sheet.frame->width / 2;
+        if (options.mask_detection_parameters.maximum_width == -1) {
+          options.mask_detection_parameters.maximum_width =
+              sheet.frame->width / 2;
         }
-        if (maskScanMaximum[HEIGHT] == -1) {
-          maskScanMaximum[HEIGHT] = sheet.frame->height;
+        if (options.mask_detection_parameters.maximum_height == -1) {
+          options.mask_detection_parameters.maximum_height =
+              sheet.frame->height;
         }
         if (middleWipe[0] > 0 || middleWipe[1] > 0) { // left, right
           wipes.areas[wipes.count++] = (Rectangle){{
@@ -1597,8 +1602,8 @@ int main(int argc, char *argv[]) {
           }};
         }
         // avoid inner half of each page to be blackfilter-detectable
-        if (blackfilterExcludeCount ==
-            0) { // no manual settings, use auto-values
+        if (options.blackfilter_parameters.exclusions_count == 0) {
+          // no manual settings, use auto-values
           RectangleSize sheetSize = size_of_image(sheet);
           RectangleSize filterSize = {
               .width = sheetSize.width / 4,
@@ -1608,9 +1613,11 @@ int main(int argc, char *argv[]) {
           Point secondFilterOrigin =
               shift_point(firstFilterOrigin, (Delta){sheet.frame->width / 2});
 
-          blackfilterExclude[blackfilterExcludeCount++] =
+          options.blackfilter_parameters
+              .exclusions[options.blackfilter_parameters.exclusions_count++] =
               rectangle_from_size(firstFilterOrigin, filterSize);
-          blackfilterExclude[blackfilterExcludeCount++] =
+          options.blackfilter_parameters
+              .exclusions[options.blackfilter_parameters.exclusions_count++] =
               rectangle_from_size(secondFilterOrigin, filterSize);
         }
         // set two outside borders to start scanning for final border-scan
@@ -1626,11 +1633,11 @@ int main(int argc, char *argv[]) {
       }
       // if maskScanMaximum still unset (no --layout specified), set to full
       // sheet size now
-      if (maskScanMinimum[WIDTH] == -1) {
-        maskScanMaximum[WIDTH] = sheet.frame->width;
+      if (options.mask_detection_parameters.maximum_width == -1) {
+        options.mask_detection_parameters.maximum_width = sheet.frame->width;
       }
-      if (maskScanMinimum[HEIGHT] == -1) {
-        maskScanMaximum[HEIGHT] = sheet.frame->height;
+      if (options.mask_detection_parameters.maximum_height == -1) {
+        options.mask_detection_parameters.maximum_height = sheet.frame->height;
       }
 
       // pre-wipe


### PR DESCRIPTION
When applying per-input adjustment, make sure to update them in the parameters.

This wasn't very obvious because all of the temporary variables are still visible
after parameter validations completed.

It also isn't the best design insofar as it allows changes to happen outside
of the validation routines, but it will have to do for now.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/210).
* __->__ #210
* #209