### PR TITLE
Move logging to the filters.

### DIFF
--- a/imageprocess/filters.h
+++ b/imageprocess/filters.h
@@ -50,10 +50,10 @@ bool validate_blurfilter_parameters(BlurfilterParameters *params,
                                     RectangleSize scan_size, Delta scan_step,
                                     float intensity);
 
-uint64_t blurfilter(Image image, BlurfilterParameters params,
-                    uint8_t abs_white_threshold);
+void blurfilter(Image image, BlurfilterParameters params,
+                uint8_t abs_white_threshold);
 
-uint64_t noisefilter(Image image, uint64_t intensity, uint8_t min_white_level);
+void noisefilter(Image image, uint64_t intensity, uint8_t min_white_level);
 
 typedef struct {
   RectangleSize scan_size;
@@ -67,4 +67,4 @@ bool validate_grayfilter_parameters(GrayfilterParameters *params,
                                     RectangleSize scan_size, Delta scan_step,
                                     float threshold);
 
-uint64_t grayfilter(Image image, GrayfilterParameters params);
+void grayfilter(Image image, GrayfilterParameters params);

--- a/unpaper.c
+++ b/unpaper.c
@@ -1672,15 +1672,10 @@ int main(int argc, char *argv[]) {
       // noise filter
       if (!isExcluded(nr, options.no_noisefilter_multi_index,
                       options.ignore_multi_index)) {
-        verboseLog(VERBOSE_NORMAL, "noise-filter ...");
-
         saveDebug("_before-noisefilter%d.pnm", nr, sheet);
-        uint64_t filterResult = noisefilter(
-            sheet, options.noisefilter_intensity, options.abs_white_threshold);
+        noisefilter(sheet, options.noisefilter_intensity,
+                    options.abs_white_threshold);
         saveDebug("_after-noisefilter%d.pnm", nr, sheet);
-        verboseLog(VERBOSE_NORMAL, " deleted %" PRId64 " clusters.\n",
-                   filterResult);
-
       } else {
         verboseLog(VERBOSE_MORE, "+ noisefilter DISABLED for sheet %d\n", nr);
       }
@@ -1688,15 +1683,10 @@ int main(int argc, char *argv[]) {
       // blur filter
       if (!isExcluded(nr, options.no_blurfilter_multi_index,
                       options.ignore_multi_index)) {
-        verboseLog(VERBOSE_NORMAL, "blur-filter...");
-
         saveDebug("_before-blurfilter%d.pnm", nr, sheet);
-        uint64_t filterResult = blurfilter(sheet, options.blurfilter_parameters,
-                                           options.abs_white_threshold);
+        blurfilter(sheet, options.blurfilter_parameters,
+                   options.abs_white_threshold);
         saveDebug("_after-blurfilter%d.pnm", nr, sheet);
-        verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
-                   filterResult);
-
       } else {
         verboseLog(VERBOSE_MORE, "+ blurfilter DISABLED for sheet %d\n", nr);
       }
@@ -1720,14 +1710,9 @@ int main(int argc, char *argv[]) {
       // gray filter
       if (!isExcluded(nr, options.no_grayfilter_multi_index,
                       options.ignore_multi_index)) {
-        verboseLog(VERBOSE_NORMAL, "gray-filter...");
-
         saveDebug("_before-grayfilter%d.pnm", nr, sheet);
-        uint64_t filterResult =
-            grayfilter(sheet, options.grayfilter_parameters);
+        grayfilter(sheet, options.grayfilter_parameters);
         saveDebug("_after-grayfilter%d.pnm", nr, sheet);
-        verboseLog(VERBOSE_NORMAL, " deleted %" PRIu64 " pixels.\n",
-                   filterResult);
       } else {
         verboseLog(VERBOSE_MORE, "+ grayfilter DISABLED for sheet %d\n", nr);
       }


### PR DESCRIPTION
Move logging to the filters.

This improves data locality as the count doesn't need to be returned.
