### PR TITLE
Avoid copying the source image for deskew.

### DIFF
--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -134,6 +134,8 @@ bool rectangle_overlap_any(Rectangle first_input, size_t count,
 }
 
 FloatPoint center_of_rectangle(Rectangle area) {
+  area = normalize_rectangle(area);
+
   RectangleSize size = size_of_rectangle(area);
 
   return (FloatPoint){


### PR DESCRIPTION
Avoid copying the source image for deskew.

Instead of relying on copying the source image to a new image,
calculate two center areas, and update the formula to expect
them to differ.

This allows skipping one copy per mask, although there is
still a need to copy the result back into the original image.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/220).
* #221
* __->__ #220