### PR TITLE
Inline wipes in the Options structure.

### DIFF
--- a/imageprocess/primitives.c
+++ b/imageprocess/primitives.c
@@ -134,6 +134,8 @@ bool rectangle_overlap_any(Rectangle first_input, size_t count,
 }
 
 FloatPoint center_of_rectangle(Rectangle area) {
+  area = normalize_rectangle(area);
+
   RectangleSize size = size_of_rectangle(area);
 
   return (FloatPoint){

--- a/lib/options.c
+++ b/lib/options.c
@@ -17,8 +17,6 @@ static struct MultiIndex multi_index_empty(void) {
   return (struct MultiIndex){.count = 0, .indexes = NULL};
 }
 
-static Wipes *allocate_wipes() { return calloc(1, sizeof(Wipes)); }
-
 void options_init(Options *o) {
   *o = (Options){
       .write_output = true,
@@ -56,9 +54,9 @@ void options_init(Options *o) {
       .no_border_scan_multi_index = multi_index_empty(),
       .no_border_align_multi_index = multi_index_empty(),
 
-      .pre_wipes = allocate_wipes(),
-      .wipes = allocate_wipes(),
-      .post_wipes = allocate_wipes(),
+      .pre_wipes = (Wipes){.count = 0},
+      .wipes = (Wipes){.count = 0},
+      .post_wipes = (Wipes){.count = 0},
 
       .pre_shift = (Delta){0, 0},
       .post_shift = (Delta){0, 0},

--- a/lib/options.h
+++ b/lib/options.h
@@ -49,9 +49,9 @@ typedef struct {
   struct MultiIndex no_border_scan_multi_index;
   struct MultiIndex no_border_align_multi_index;
 
-  Wipes *pre_wipes;
-  Wipes *wipes;
-  Wipes *post_wipes;
+  Wipes pre_wipes;
+  Wipes wipes;
+  Wipes post_wipes;
 
   Delta pre_shift;
   Delta post_shift;

--- a/unpaper.c
+++ b/unpaper.c
@@ -557,15 +557,15 @@ int main(int argc, char *argv[]) {
         break;
 
       case 'W':
-        parse_wipe("wipe", optarg, options.wipes);
+        parse_wipe("wipe", optarg, &options.wipes);
         break;
 
       case OPT_PRE_WIPE:
-        parse_wipe("pre-wipe", optarg, options.pre_wipes);
+        parse_wipe("pre-wipe", optarg, &options.pre_wipes);
         break;
 
       case OPT_POST_WIPE:
-        parse_wipe("post-wipe", optarg, options.post_wipes);
+        parse_wipe("post-wipe", optarg, &options.post_wipes);
         break;
 
       case OPT_MIDDLE_WIPE:
@@ -1262,10 +1262,10 @@ int main(int argc, char *argv[]) {
           printf("pre-shift: [%" PRId32 ",%" PRId32 "]\n",
                  options.pre_shift.horizontal, options.pre_shift.vertical);
         }
-        if (options.pre_wipes->count > 0) {
+        if (options.pre_wipes.count > 0) {
           printf("pre-wipe: ");
-          for (size_t i = 0; i < options.pre_wipes->count; i++) {
-            print_rectangle(options.pre_wipes->areas[i]);
+          for (size_t i = 0; i < options.pre_wipes.count; i++) {
+            print_rectangle(options.pre_wipes.areas[i]);
           }
           printf("\n");
         }
@@ -1423,10 +1423,10 @@ int main(int argc, char *argv[]) {
           printf("deskew-scan DISABLED for all sheets.\n");
         }
         if (options.no_wipe_multi_index.count != -1) {
-          if (options.wipes->count > 0) {
+          if (options.wipes.count > 0) {
             printf("wipe areas: ");
-            for (size_t i = 0; i < options.wipes->count; i++) {
-              print_rectangle(options.wipes->areas[i]);
+            for (size_t i = 0; i < options.wipes.count; i++) {
+              print_rectangle(options.wipes.areas[i]);
             }
             printf("\n");
           }
@@ -1468,10 +1468,10 @@ int main(int argc, char *argv[]) {
         } else {
           printf("border-scan DISABLED for all sheets.\n");
         }
-        if (options.post_wipes->count > 0) {
+        if (options.post_wipes.count > 0) {
           printf("post-wipe: ");
-          for (size_t i = 0; i < options.post_wipes->count; i++) {
-            print_rectangle(options.post_wipes->areas[i]);
+          for (size_t i = 0; i < options.post_wipes.count; i++) {
+            print_rectangle(options.post_wipes.areas[i]);
           }
           printf("\n");
         }
@@ -1603,7 +1603,7 @@ int main(int argc, char *argv[]) {
               sheet.frame->height;
         }
         if (middleWipe[0] > 0 || middleWipe[1] > 0) { // left, right
-          options.wipes->areas[options.wipes->count++] = (Rectangle){{
+          options.wipes.areas[options.wipes.count++] = (Rectangle){{
               {sheet.frame->width / 2 - middleWipe[0], 0},
               {sheet.frame->width / 2 + middleWipe[1], sheet.frame->height - 1},
           }};
@@ -1650,7 +1650,7 @@ int main(int argc, char *argv[]) {
       // pre-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, *options.pre_wipes, options.mask_color);
+        apply_wipes(sheet, options.pre_wipes, options.mask_color);
       }
 
       // pre-border
@@ -1781,7 +1781,7 @@ int main(int argc, char *argv[]) {
       // explicit wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, *options.wipes, options.mask_color);
+        apply_wipes(sheet, options.wipes, options.mask_color);
       } else {
         verboseLog(VERBOSE_MORE, "+ wipe DISABLED for sheet %d\n", nr);
       }
@@ -1825,7 +1825,7 @@ int main(int argc, char *argv[]) {
       // post-wipe
       if (!isExcluded(nr, options.no_wipe_multi_index,
                       options.ignore_multi_index)) {
-        apply_wipes(sheet, *options.post_wipes, options.mask_color);
+        apply_wipes(sheet, options.post_wipes, options.mask_color);
       }
 
       // post-border


### PR DESCRIPTION
Inline wipes in the Options structure.

This does not make much of a difference besides to the size
of the Options structure itself, but it allows copying these
into a per-sheet structure more easily, if needed.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/unpaper/unpaper/pull/221).
* __->__ #221
* #220