### PR TITLE
Fix range-based multiindex parsing

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -87,7 +87,8 @@ void parseMultiIndex(const char *optarg, struct MultiIndex *multiIndex) {
         size_t count = index - multiIndex->indexes[(multiIndex->count) - 1];
 
         allocated += count;
-        multiIndex->indexes = realloc(multiIndex->indexes, allocated);
+        multiIndex->indexes = realloc(
+            multiIndex->indexes, allocated * sizeof(multiIndex->indexes[0]));
 
         for (int j = multiIndex->indexes[(multiIndex->count) - 1] + 1;
              j <= index; j++) {

--- a/tests/unpaper_tests.py
+++ b/tests/unpaper_tests.py
@@ -461,3 +461,13 @@ def test_invalid_multi_index(imgsrc_path, tmp_path):
         "--no-processing", "1-", str(source_path), str(result_path), check=False
     )
     assert unpaper_result.returncode != 0
+
+
+def test_valid_range_multi_index(imgsrc_path, tmp_path):
+    source_path = imgsrc_path / "imgsrc%03.png"
+    result_path = tmp_path / "result%03.pbm"
+    unpaper_result = run_unpaper(
+        "--no-processing", "1-100", str(source_path), str(result_path), check=False
+    )
+    assert unpaper_result.returncode == 0
+


### PR DESCRIPTION
Wrong size passed to realloc().

Fixes #48